### PR TITLE
Update Adafruit_PWMServoDriver.cpp  Fixed setPWM - beginTransmission now works

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -50,13 +50,14 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
   write8(PCA9685_PRESCALE, prescale); // set the prescaler
   write8(PCA9685_MODE1, oldmode);
   delay(5);
-  write8(PCA9685_MODE1, oldmode | 0x80);
+  //write8(PCA9685_MODE1, oldmode | 0x80);
+  write8(PCA9685_MODE1, oldmode | 0xa1);  //  This sets the MODE1 register to turn on auto increment.
+                                          // This is why the beginTransmission below was not working.
   //  Serial.print("Mode now 0x"); Serial.println(read8(PCA9685_MODE1), HEX);
 }
 
 void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
-  /*
-  // hmm doesnt work, whyso?
+  // hmm doesnt work, whyso?  (  Not in AI mode.  See line 54 above.  ( Works now!!  :D  )
   Wire.beginTransmission(_i2caddr);
   Wire.write(LED0_ON_L+4*num);
   Wire.write(on);
@@ -64,11 +65,13 @@ void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
   Wire.write(off);
   Wire.write(off>>8);
   Wire.endTransmission();
-  */
+  
+/*  
   write8(LED0_ON_L+4*num, on);
   write8(LED0_ON_H+4*num, on >> 8);
   write8(LED0_OFF_L+4*num, off);
-  write8(LED0_OFF_H+4*num, off >> 8);  
+  write8(LED0_OFF_H+4*num, off >> 8);
+*/
 }
 
 uint8_t Adafruit_PWMServoDriver::read8(uint8_t addr) {


### PR DESCRIPTION
Hi!

So happy to be able to contribute.

Corrected setPWM.  Transmission now works.

Line 53:  Set MODE1 register to " old mode or 0xA1"
This enables autoincrement allowing multibyte transmissions to be sent.

Can now set a sequence of regsiters in one transmission.
