### PR TITLE
Update "off" to reflect data sheet table

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -63,6 +63,10 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
 void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
   //Serial.print("Setting PWM "); Serial.print(num); Serial.print(": "); Serial.print(on); Serial.print("->"); Serial.println(off);
 
+  if(off == 0)
+  {
+  	off = 4096;
+  }
   WIRE.beginTransmission(_i2caddr);
   WIRE.write(LED0_ON_L+4*num);
   WIRE.write(on);


### PR DESCRIPTION
The data sheet Table 6 specifies that 4096 needs to be written to a
channel in the off register in order to fully turn off the output.
Writing a 0 for off will result in a small waveform being produced and
the LEDs will not be fully dark.
