### PR TITLE
Added separate WIRE define for Teensy boards

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -17,7 +17,9 @@
 
 #include <Adafruit_PWMServoDriver.h>
 #include <Wire.h>
-#ifdef __AVR__
+#if defined(__AVR__)
+ #define WIRE Wire
+#elif defined(CORE_TEENSY) // Teensy boards
  #define WIRE Wire
 #else // Arduino Due
  #define WIRE Wire1


### PR DESCRIPTION
Teensy boards use the same Wire API as Arduino, but newer Teensy boards don't use the AVR microcontroller (and therefore do not have __ AVR __ defined).  I added in a check and #define for CORE_TEENSY to cover current and future Teensy boards, regardless of what chip they use.
