### PR TITLE
Added separate WIRE define for ESP8266 boards

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -21,6 +21,8 @@
  #define WIRE Wire
 #elif defined(CORE_TEENSY) // Teensy boards
  #define WIRE Wire
+#elif defined(ESP8266)
+ #define WIRE Wire
 #else // Arduino Due
  #define WIRE Wire1
 #endif


### PR DESCRIPTION
ESP8266 boards don't define __ AVR __ (or CORE_TEENSY) so they currently default to the Wire1 library instead of Wire, causing compiles to fail with:
        error: 'Wire1' was not declared in this scope
        #define WIRE Wire1

Similar to pull request #12 (which added TEENSY support), this request aims to add ESP8266 support.
