### PR TITLE
Adafruit_PWMServoDriver::begin method for specifying alternate I2C SDA/SCL pins

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -37,6 +37,10 @@ void Adafruit_PWMServoDriver::begin(void) {
  reset();
 }
 
+void Adafruit_PWMServoDriver::begin(int sda, int scl) {
+ WIRE.begin(sda, scl);
+ reset();
+}
 
 void Adafruit_PWMServoDriver::reset(void) {
  write8(PCA9685_MODE1, 0x0);

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -47,6 +47,7 @@ class Adafruit_PWMServoDriver {
  public:
   Adafruit_PWMServoDriver(uint8_t addr = 0x40);
   void begin(void);
+  void begin(int sda, int scl);
   void reset(void);
   void setPWMFreq(float freq);
   void setPWM(uint8_t num, uint16_t on, uint16_t off);


### PR DESCRIPTION
On ESP8266_ESP01 the only gpios available for SDA/SCL are (0,2). The Wire library overloads the begin method to allow to specify alternate pins for sda and scl.

This pull provides an Adafruit_PWMServoDriver::begin(int sda, int scl) method that allows for passing through alternate sda/scl pins to the underlying Wire library.