### PR TITLE
Wire.pins() removed, deprecated

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -50,11 +50,11 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
   prescaleval /= freq;
   prescaleval -= 1;
   if (ENABLE_DEBUG_OUTPUT) {
-    Serial.print("Estimated pre-scale: "); Serial.println(prescaleval);
+    //Serial.print("Estimated pre-scale: "); Serial.println(prescaleval);
   }
   uint8_t prescale = floor(prescaleval + 0.5);
   if (ENABLE_DEBUG_OUTPUT) {
-    Serial.print("Final pre-scale: "); Serial.println(prescale);
+    //Serial.print("Final pre-scale: "); Serial.println(prescale);
   }
   
   uint8_t oldmode = read8(PCA9685_MODE1);

--- a/examples/servo/servo.pde
+++ b/examples/servo/servo.pde
@@ -38,10 +38,6 @@ void setup() {
   Serial.begin(9600);
   Serial.println("16 channel Servo test!");
 
-#ifdef ESP8266
-  Wire.pins(2, 14);   // ESP8266 can use any two pins, such as SDA to #2 and SCL to #14
-#endif
-
   pwm.begin();
   
   pwm.setPWMFreq(60);  // Analog servos run at ~60 Hz updates


### PR DESCRIPTION
Wire.pins() is deprecated for ESP8266. Defaults for SDA/SCL are pins 4
and 5.