### PR TITLE
Dont release control of the bus

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -118,7 +118,7 @@ void Adafruit_PWMServoDriver::setPin(uint8_t num, uint16_t val, bool invert)
 uint8_t Adafruit_PWMServoDriver::read8(uint8_t addr) {
   WIRE.beginTransmission(_i2caddr);
   WIRE.write(addr);
-  WIRE.endTransmission();
+  WIRE.endTransmission(false);
 
   WIRE.requestFrom((uint8_t)_i2caddr, (uint8_t)1);
   return WIRE.read();


### PR DESCRIPTION
# Scope

This is a simple change. It ensures that the bus is not released in between preparing the read address and carrying out the read on the device.
# Limitations

Limitation is that Arduino V1.0.1 or greater is required.
# Tests

Works on my board
# Commit Message

If false is passed to endTransmission(), it will send a restart message after transmission instead of a stop. The bus will not be released, which prevents another master device from transmitting between messages.

This is critical as we are in the middle of preparing a read.

Requires Arduino V1.0.1+
