### PR TITLE
Debug output fix

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -42,19 +42,23 @@ void Adafruit_PWMServoDriver::reset(void) {
 }
 
 void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
-  //Serial.print("Attempting to set freq ");
-  //Serial.println(freq);
+  if (ENABLE_DEBUG_OUTPUT) {
+    Serial.print("Attempting to set freq ");
+    Serial.println(freq);
+  }
   freq *= 0.9;  // Correct for overshoot in the frequency setting (see issue #11).
   float prescaleval = 25000000;
   prescaleval /= 4096;
   prescaleval /= freq;
   prescaleval -= 1;
   if (ENABLE_DEBUG_OUTPUT) {
-    //Serial.print("Estimated pre-scale: "); Serial.println(prescaleval);
+    Serial.print("Estimated pre-scale: ");
+    Serial.println(prescaleval);
   }
   uint8_t prescale = floor(prescaleval + 0.5);
   if (ENABLE_DEBUG_OUTPUT) {
-    //Serial.print("Final pre-scale: "); Serial.println(prescale);
+    Serial.print("Final pre-scale: ");
+    Serial.println(prescale);
   }
   
   uint8_t oldmode = read8(PCA9685_MODE1);
@@ -65,11 +69,21 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
   delay(5);
   write8(PCA9685_MODE1, oldmode | 0xa1);  //  This sets the MODE1 register to turn on auto increment.
                                           // This is why the beginTransmission below was not working.
-  //  Serial.print("Mode now 0x"); Serial.println(read8(PCA9685_MODE1), HEX);
+  if (ENABLE_DEBUG_OUTPUT){
+   Serial.print("Mode now 0x");
+   Serial.println(read8(PCA9685_MODE1), HEX);
+  }
 }
 
 void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
-  //Serial.print("Setting PWM "); Serial.print(num); Serial.print(": "); Serial.print(on); Serial.print("->"); Serial.println(off);
+  if (ENABLE_DEBUG_OUTPUT){
+    Serial.print("Setting PWM ");
+    Serial.print(num);
+    Serial.print(": ");
+    Serial.print(on);
+    Serial.print("->");
+    Serial.println(off);
+  }
 
   WIRE.beginTransmission(_i2caddr);
   WIRE.write(LED0_ON_L+4*num);

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -42,25 +42,25 @@ void Adafruit_PWMServoDriver::reset(void) {
 }
 
 void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
-  if (ENABLE_DEBUG_OUTPUT) {
+  #if (ENABLE_DEBUG_OUTPUT)
     Serial.print("Attempting to set freq ");
     Serial.println(freq);
-  }
+  #endif
   freq *= 0.9;  // Correct for overshoot in the frequency setting (see issue #11).
   float prescaleval = 25000000;
   prescaleval /= 4096;
   prescaleval /= freq;
   prescaleval -= 1;
-  if (ENABLE_DEBUG_OUTPUT) {
+  #if (ENABLE_DEBUG_OUTPUT)
     Serial.print("Estimated pre-scale: ");
     Serial.println(prescaleval);
-  }
+  #endif
   uint8_t prescale = floor(prescaleval + 0.5);
-  if (ENABLE_DEBUG_OUTPUT) {
+  #if (ENABLE_DEBUG_OUTPUT)
     Serial.print("Final pre-scale: ");
     Serial.println(prescale);
-  }
-  
+  #endif
+
   uint8_t oldmode = read8(PCA9685_MODE1);
   uint8_t newmode = (oldmode&0x7F) | 0x10; // sleep
   write8(PCA9685_MODE1, newmode); // go to sleep
@@ -69,21 +69,21 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
   delay(5);
   write8(PCA9685_MODE1, oldmode | 0xa1);  //  This sets the MODE1 register to turn on auto increment.
                                           // This is why the beginTransmission below was not working.
-  if (ENABLE_DEBUG_OUTPUT){
+  #if (ENABLE_DEBUG_OUTPUT)
    Serial.print("Mode now 0x");
    Serial.println(read8(PCA9685_MODE1), HEX);
-  }
+  #endif
 }
 
 void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
-  if (ENABLE_DEBUG_OUTPUT){
+  #if (ENABLE_DEBUG_OUTPUT)
     Serial.print("Setting PWM ");
     Serial.print(num);
     Serial.print(": ");
     Serial.print(on);
     Serial.print("->");
     Serial.println(off);
-  }
+  #endif
 
   WIRE.beginTransmission(_i2caddr);
   WIRE.write(LED0_ON_L+4*num);


### PR DESCRIPTION
I removed the comments from the debug messages and put them under preprocessors directives. This way enabling them by settings ENABLE_DEBUG_OUTPUT to true will work again.

From what I understood they were commented out to enable compiling for platforms that do not support Serial.prints such as the ATTINY85 but they will work if they are hidden under a preprocessors directive since they will never hit the compiler.

I tested it on my Arduino Uno (including trying to call Serial1.print which should cause same compiler error as Serial.print on ATTINY85)and it worked.