### PR TITLE
Use correct include syntax

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -15,7 +15,7 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Adafruit_PWMServoDriver.h>
+#include "Adafruit_PWMServoDriver.h"
 #include <Wire.h>
 
 // Set to true to print some debug messages, or false to disable them.

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -19,11 +19,11 @@
 #define _ADAFRUIT_PWMServoDriver_H
 
 #if ARDUINO >= 100
- #include "Arduino.h"
+ #include <Arduino.h>
 #else
- #include "WProgram.h"
+ #include <WProgram.h>
 #endif
-#include "Wire.h"
+#include <Wire.h>
 
 #define PCA9685_SUBADR1 0x2
 #define PCA9685_SUBADR2 0x3


### PR DESCRIPTION
Angle brackets for external includes. Quotes for internal includes. The former is not critical but the latter is necessary in order to use the library bundled with a sketch, where Adafruit_PWMServoDriver.h will not be found in the include search path.