### PR TITLE
Added to use the External Clock by configuring the EXTCLK bit

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -53,13 +53,22 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(TwoWire *i2c, uint8_t addr) {
 /**************************************************************************/
 /*! 
     @brief  Setups the I2C interface and hardware
+	@param  prescale If value is non-zero, configure to use external clock
 */
 /**************************************************************************/
-void Adafruit_PWMServoDriver::begin(void) {
+void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   _i2c->begin();
   reset();
-  // set a default frequency
-  setPWMFreq(1000);
+  
+  if(prescale)
+  {
+    setExtClk(prescale);
+  }
+  else
+  {
+    // set a default frequency
+    setPWMFreq(1000);
+  }
 }
 
 
@@ -109,6 +118,30 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
   write8(PCA9685_MODE1, oldmode | 0xa0);  //  This sets the MODE1 register to turn on auto increment.
 
 #ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Mode now 0x"); Serial.println(read8(PCA9685_MODE1), HEX);
+#endif
+}
+
+/**************************************************************************/
+/*! 
+    @brief  Sets EXTCLK pin to use the external clock
+	@param  prescale Configures the prescale value to be used by the external clock
+*/
+/**************************************************************************/
+void Adafruit_PWMServoDriver::setExtClk(uint8_t prescale) {
+  uint8_t oldmode = read8(PCA9685_MODE1);
+  uint8_t newmode = (oldmode&0x7F) | 0x10; // sleep
+  write8(PCA9685_MODE1, newmode); // go to sleep, turn off internal oscillator
+  
+  // This sets both the SLEEP and EXTCLK bits of the MODE1 register to switch to use the external clock.
+  write8(PCA9685_MODE1, (newmode |= 0x40));
+  
+  write8(PCA9685_PRESCALE, prescale); // set the prescaler
+  
+  delay(5);
+  write8(PCA9685_MODE1, (newmode & ~(0x10)) | 0xa0); //clear the SLEEP bit to start
+  
+  #ifdef ENABLE_DEBUG_OUTPUT
   Serial.print("Mode now 0x"); Serial.println(read8(PCA9685_MODE1), HEX);
 #endif
 }

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -51,9 +51,10 @@ class Adafruit_PWMServoDriver {
  public:
   Adafruit_PWMServoDriver(uint8_t addr = 0x40);
   Adafruit_PWMServoDriver(TwoWire *I2C, uint8_t addr = 0x40);
-  void begin(void);
+  void begin(uint8_t prescale = 0);
   void reset(void);
   void setPWMFreq(float freq);
+  void setExtClk(uint8_t prescale);
   void setPWM(uint8_t num, uint16_t on, uint16_t off);
   void setPin(uint8_t num, uint16_t val, bool invert=false);
 


### PR DESCRIPTION
Modified the begin() to enable the user to configure to use the external clock if the passed in argument is non-zero. This value will in turn be passed into setExtClk() to configure the driver chip to use the External Clock.

Tested the code changes on my project https://github.com/randall86/LED_Tester_System
