### PR TITLE
improved "Issue 11" solution based on measurements

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -88,8 +88,8 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
 #endif
 
   //freq *= 0.9;  // Correct for overshoot in the frequency setting (see issue #11).
-  uint32_t prescaleval = _clock_frequency / freq
-  prescaleval -= 2048 // instead of rounding and -1, -0.5 (2048/4096) and get rid of decimals
+  uint32_t prescaleval = _clock_frequency / freq;
+  prescaleval -= 2048; // instead of rounding and -1, -0.5 (2048/4096) and get rid of decimals
   prescaleval /= 4096; // divide by 4096
 
   uint8_t prescale = prescaleval & 0xFF;

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -1,17 +1,17 @@
-/*************************************************** 
+/***************************************************
   This is a library for our Adafruit 16-channel PWM & Servo driver
 
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/815
 
-  These displays use I2C to communicate, 2 pins are required to  
+  These displays use I2C to communicate, 2 pins are required to
   interface.
 
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -23,13 +23,14 @@
 
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on the Wire interface. On Due we use Wire1 since its the interface on the 'default' I2C pins.
     @param  addr The 7-bit I2C address to locate this chip, default is 0x40
 */
 /**************************************************************************/
 Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(uint8_t addr) {
   _i2caddr = addr;
+  _clock_frequency = OSCILLATOR_CLOCK_FREQUENCY;
 
 #if defined(ARDUINO_SAM_DUE)
   _i2c = &Wire1;
@@ -39,7 +40,7 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(uint8_t addr) {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on a TwoWire interface
     @param  i2c  A pointer to a 'Wire' compatible object that we'll use to communicate with
     @param  addr The 7-bit I2C address to locate this chip, default is 0x40
@@ -48,10 +49,11 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(uint8_t addr) {
 Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(TwoWire *i2c, uint8_t addr) {
   _i2c = i2c;
   _i2caddr = addr;
+  _clock_frequency = OSCILLATOR_CLOCK_FREQUENCY;
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Setups the I2C interface and hardware
 */
 /**************************************************************************/
@@ -64,17 +66,17 @@ void Adafruit_PWMServoDriver::begin(void) {
 
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Sends a reset command to the PCA9685 chip over I2C
 */
 /**************************************************************************/
 void Adafruit_PWMServoDriver::reset(void) {
-  write8(PCA9685_MODE1, 0x80);
+  write8(PCA9685_MODE1, MODE1_RESTART);
   delay(10);
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Sets the PWM frequency for the entire chip, up to ~1.6 KHz
     @param  freq Floating point frequency that we will attempt to match
 */
@@ -85,28 +87,25 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
   Serial.println(freq);
 #endif
 
-  freq *= 0.9;  // Correct for overshoot in the frequency setting (see issue #11).
-  float prescaleval = 25000000;
-  prescaleval /= 4096;
-  prescaleval /= freq;
-  prescaleval -= 1;
+  //freq *= 0.9;  // Correct for overshoot in the frequency setting (see issue #11).
+  uint32_t prescaleval = _clock_frequency / freq
+  prescaleval -= 2048 // instead of rounding and -1, -0.5 (2048/4096) and get rid of decimals
+  prescaleval /= 4096; // divide by 4096
 
-#ifdef ENABLE_DEBUG_OUTPUT
-  Serial.print("Estimated pre-scale: "); Serial.println(prescaleval);
-#endif
+  uint8_t prescale = prescaleval & 0xFF;
+  if (prescale < 3) prescale = 3;
 
-  uint8_t prescale = floor(prescaleval + 0.5);
 #ifdef ENABLE_DEBUG_OUTPUT
   Serial.print("Final pre-scale: "); Serial.println(prescale);
 #endif
-  
+
   uint8_t oldmode = read8(PCA9685_MODE1);
-  uint8_t newmode = (oldmode&0x7F) | 0x10; // sleep
+  uint8_t newmode = (oldmode ~ MODE1_RESTART) | MODE1_SLEEP; // sleep
   write8(PCA9685_MODE1, newmode); // go to sleep
   write8(PCA9685_PRESCALE, prescale); // set the prescaler
   write8(PCA9685_MODE1, oldmode);
   delay(5);
-  write8(PCA9685_MODE1, oldmode | 0xa0);  //  This sets the MODE1 register to turn on auto increment.
+  write8(PCA9685_MODE1, oldmode | MODE1_AI | MODE1_RESTART);  //  This sets the MODE1 register to turn on auto increment.
 
 #ifdef ENABLE_DEBUG_OUTPUT
   Serial.print("Mode now 0x"); Serial.println(read8(PCA9685_MODE1), HEX);
@@ -114,7 +113,7 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Sets the PWM output of one of the PCA9685 pins
     @param  num One of the PWM output pins, from 0 to 15
     @param  on At what point in the 4096-part cycle to turn the PWM output ON
@@ -127,7 +126,7 @@ void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
 #endif
 
   _i2c->beginTransmission(_i2caddr);
-  _i2c->write(LED0_ON_L+4*num);
+  _i2c->write(PCA9685_LED0_ON_L+4*num);
   _i2c->write(on);
   _i2c->write(on>>8);
   _i2c->write(off);
@@ -136,7 +135,7 @@ void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Helper to set pin PWM output. Sets pin without having to deal with on/off tick placement and properly handles a zero value as completely off and 4095 as completely on.  Optional invert parameter supports inverting the pulse for sinking to ground.
     @param  num One of the PWM output pins, from 0 to 15
     @param  val The number of ticks out of 4096 to be active, should be a value from 0 to 4095 inclusive.
@@ -173,6 +172,29 @@ void Adafruit_PWMServoDriver::setPin(uint8_t num, uint16_t val, bool invert)
       setPWM(num, 0, val);
     }
   }
+}
+
+/**************************************************************************/
+/*!
+    @brief  Correct the Oscillator clock frequency used in calculation of the pre-scaler
+    @param  Oscillator clock frequency to use in stead of 25 MHz
+*/
+/**************************************************************************/
+void Adafruit_PWMServoDriver::setClockFreq(uint32_t freq)
+{
+  if (freq > 2 * OSCILLATOR_CLOCK_FREQUENCY) {
+    #ifdef ENABLE_DEBUG_OUTPUT
+      Serial.println("Exceeding Oscillator clock frequency upperbound");
+    #endif
+    return;
+  }
+  if (2 * freq < OSCILLATOR_CLOCK_FREQUENCY) {
+    #ifdef ENABLE_DEBUG_OUTPUT
+      Serial.println("Exceeding Oscillator clock frequency lowerbound");
+    #endif
+    return;
+  }
+  _clock_frequency = freq;
 }
 
 /*******************************************************************************************/

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -1,17 +1,17 @@
-/*************************************************** 
+/***************************************************
   This is a library for our Adafruit 16-channel PWM & Servo driver
 
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/815
 
-  These displays use I2C to communicate, 2 pins are required to  
+  These displays use I2C to communicate, 2 pins are required to
   interface. For Arduino UNOs, thats SCL -> Analog 5, SDA -> Analog 4
 
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -25,25 +25,46 @@
 #endif
 #include "Wire.h"
 
-#define PCA9685_SUBADR1 0x2
-#define PCA9685_SUBADR2 0x3
-#define PCA9685_SUBADR3 0x4
+// REGISTER ADDRESSES
+#define PCA9685_MODE1        0x00
+#define PCA9685_MODE2        0x01
+#define PCA9685_SUBADR1      0x02
+#define PCA9685_SUBADR2      0x03
+#define PCA9685_SUBADR3      0x04
+#define PCA9685_ALLCALLADR   0x05
+#define PCA9685_LED0_ON_L    0x06
+#define PCA9685_LED0_ON_H    0x07
+#define PCA9685_LED0_OFF_L   0x08
+#define PCA9685_LED0_OFF_H   0x09
+// etc all 16:  LED15_OFF_H 0x45
+#define PCA9685_ALLLED_ON_L  0xFA // bit 0-7
+#define PCA9685_ALLLED_ON_H  0xFB // bit
+#define PCA9685_ALLLED_OFF_L 0xFC
+#define PCA9685_ALLLED_OFF_H 0xFD
+#define PCA9685_PRESCALE     0xFE
+#define PCA9685_TESTMODE     0xFF
 
-#define PCA9685_MODE1 0x0
-#define PCA9685_PRESCALE 0xFE
+// MODE1 bits
+#define MODE1_ALLCAL         0x01
+#define MODE1_SUB3           0x02
+#define MODE1_SUB2           0x04
+#define MODE1_SUB3           0x08
+#define MODE1_SLEEP          0x10
+#define MODE1_AI             0x20
+#define MODE1_EXTCLK         0x40
+#define MODE1_RESTART        0x80
+// MODE2 bits
+#define MODE2_OUTNE_0        0x01
+#define MODE2_OUTNE_1        0x02
+#define MODE2_OUTDRV         0x04
+#define MODE2_OCH            0x08
+#define MODE2_INVRT          0x10
 
-#define LED0_ON_L 0x6
-#define LED0_ON_H 0x7
-#define LED0_OFF_L 0x8
-#define LED0_OFF_H 0x9
+#define OSCILLATOR_CLOCK_FREQUENCY  25000000
 
-#define ALLLED_ON_L 0xFA
-#define ALLLED_ON_H 0xFB
-#define ALLLED_OFF_L 0xFC
-#define ALLLED_OFF_H 0xFD
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Class that stores state and functions for interacting with PCA9685 PWM chip
 */
 /**************************************************************************/
@@ -56,10 +77,12 @@ class Adafruit_PWMServoDriver {
   void setPWMFreq(float freq);
   void setPWM(uint8_t num, uint16_t on, uint16_t off);
   void setPin(uint8_t num, uint16_t val, bool invert=false);
+  void setClockFreq(uint32_t freq);
 
  private:
   uint8_t _i2caddr;
-  
+  uint32_t _clock_frequency;
+
   TwoWire *_i2c;
 
   uint8_t read8(uint8_t addr);

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -61,7 +61,7 @@
 #define MODE2_INVRT          0x10
 
 #define OSCILLATOR_CLOCK_FREQUENCY  25000000
-
+#define BETTER_FREQUENCY            26075000 // 4,3% higher
 
 /**************************************************************************/
 /*!

--- a/examples/servo/servo.ino
+++ b/examples/servo/servo.ino
@@ -1,19 +1,19 @@
-/*************************************************** 
+/***************************************************
   This is an example for our Adafruit 16-channel PWM & Servo driver
   Servo test - this will drive 8 servos, one after the other on the
   first 8 pins of the PCA9685
 
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/815
-  
-  These drivers use I2C to communicate, 2 pins are required to  
+
+  These drivers use I2C to communicate, 2 pins are required to
   interface.
 
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -27,7 +27,7 @@ Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 // you can also call it with a different address and I2C interface
 //Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(&Wire, 0x40);
 
-// Depending on your servo make, the pulse width min and max may vary, you 
+// Depending on your servo make, the pulse width min and max may vary, you
 // want these to be as small/large as possible without hitting the hard stop
 // for max range. You'll have to tweak them as necessary to match the servos you
 // have!
@@ -42,7 +42,7 @@ void setup() {
   Serial.println("8 channel Servo test!");
 
   pwm.begin();
-  
+  pwm.setClockFreq(BETTER_FREQUENCY);
   pwm.setPWMFreq(60);  // Analog servos run at ~60 Hz updates
 
   delay(10);
@@ -52,12 +52,12 @@ void setup() {
 // e.g. setServoPulse(0, 0.001) is a ~1 millisecond pulse width. its not precise!
 void setServoPulse(uint8_t n, double pulse) {
   double pulselength;
-  
+
   pulselength = 1000000;   // 1,000,000 us per second
   pulselength /= 60;   // 60 Hz
-  Serial.print(pulselength); Serial.println(" us per period"); 
+  Serial.print(pulselength); Serial.println(" us per period");
   pulselength /= 4096;  // 12 bits of resolution
-  Serial.print(pulselength); Serial.println(" us per bit"); 
+  Serial.print(pulselength); Serial.println(" us per bit");
   pulse *= 1000000;  // convert to us
   pulse /= pulselength;
   Serial.println(pulse);


### PR DESCRIPTION
Scope of change:
The real frequency deviates from the 25MHz frequency, this was first corrected with a 10% adjustment (issue 11). Measurements on a single board - I will upload the code so more people can do their own measurements - learned a 4,3% correction was needed.

This did me introduce a new function setClockFreq(freq) to adjust the oscillator clock frequency as used in the calculations from 25 MHz to approx. 26075000 (104,3%). Maybe it is preferred to make this the standard, if more users confirm this frequency is giving the best outcome. Otherwise people could set their own frequency with this function.

I added some more constants to lower the number of magic numbers in the code.

See one of the adjusted examples for how it can be used.

I will upload the code how I did the measurements (nothing fancy) but first I will add some NTP function (I dont trust the ESP8266 clock too much).