### PR TITLE
Removed ambiguity of requestFrom call

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -46,7 +46,7 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(TwoWire *i2c, uint8_t addr) {
  *  @brief  Setups the I2C interface and hardware
  *  @param  prescale
  *          Sets External Clock (Optional)
- *          
+ *
  */
 void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   _i2c->begin();
@@ -164,7 +164,7 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
  *  @return requested PWM output value
  */
 uint8_t Adafruit_PWMServoDriver::getPWM(uint8_t num) {
-  _i2c->requestFrom((uint8_t)_i2caddr, LED0_ON_L + 4 * num, (uint8_t)4);
+  _i2c->requestFrom((int)_i2caddr, LED0_ON_L + 4 * num, (int)4);
   return _i2c->read();
 }
 


### PR DESCRIPTION
This removes the ambiguity of the `requestFrom` call and fixes #49. The reason this issue occurred was, because there are two candidates for `requestFrom`:

```
/Applications/Arduino.app/Contents/Java/hardware/arduino/avr/libraries/Wire/src/Wire.h:62:13: note: candidate: 'uint8_t TwoWire::requestFrom(uint8_t, uint8_t, uint8_t)'
   62 |     uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
      |             ^~~~~~~~~~~
/Applications/Arduino.app/Contents/Java/hardware/arduino/avr/libraries/Wire/src/Wire.h:65:13: note: candidate: 'uint8_t TwoWire::requestFrom(int, int, int)'
   65 |     uint8_t requestFrom(int, int, int);
      |             ^~~~~~~~~~~
```

The PWMServoDriver library code used a mixture of `uint8_t` and `int` (second parameter). Since for the second parameter the value will be multiplied with an `uint8_t` (which could in theory be the maximum allowed value it makes sense to use `int` here. If the code could make sure that the second parameter won't result in a number higher than 255, this could be changed to use `uint8_t` for every parameter.
