### PR TITLE
Implemented a method for changing the pin output mode

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -163,7 +163,7 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
  *  open drain or push pull / totempole. 
  *  Warning: LEDs with integrated zener diodes should
  *  only be driven in open drain mode. 
- *  @param  pushPull totempole if true, open drain if false. 
+ *  @param  totempole Totempole if true, open drain if false. 
  */
 void Adafruit_PWMServoDriver::setOutputMode(bool totempole) {  
   uint8_t oldmode = read8(PCA9685_MODE2); 

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -159,6 +159,31 @@ void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
 }
 
 /*!
+ *  @brief  Sets the output mode of the PCA9685 to either 
+ *  open drain or push pull / totempole. 
+ *  Warning: LEDs with integrated zener diodes should
+ *  only be driven in open drain mode. 
+ *  @param  pushPull totempole if true, open drain if false. 
+ */
+void Adafruit_PWMServoDriver::setOutputMode(bool totempole) {  
+  uint8_t oldmode = read8(PCA9685_MODE2); 
+  uint8_t newmode;
+  if (totempole) {
+    newmode = (oldmode&0x7F) | 0x04;
+  }
+  else {
+    newmode = (oldmode&0x7F) & ~0x04;
+  }
+  write8(PCA9685_MODE2, newmode); 
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Setting output mode: ");
+  Serial.print(totempole ? "totempole" : "open drain");
+  Serial.print(" by setting MODE2 to ");
+  Serial.println(newmode);
+#endif
+}
+
+/*!
  *  @brief  Gets the PWM output of one of the PCA9685 pins
  *  @param  num One of the PWM output pins, from 0 to 15
  *  @return requested PWM output value

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -19,7 +19,6 @@
  *
  *  BSD license, all text above must be included in any redistribution
  */
-
 #ifndef _ADAFRUIT_PWMServoDriver_H
 #define _ADAFRUIT_PWMServoDriver_H
 
@@ -31,6 +30,7 @@
 #define PCA9685_SUBADR3 0x4 /**< i2c bus address 3 */
 
 #define PCA9685_MODE1 0x0 /**< Mode Register 1 */
+#define PCA9685_MODE2 0x1 /**< Mode Register 2 */
 #define PCA9685_PRESCALE 0xFE /**< Prescaler for PWM output frequency */
 
 #define LED0_ON_L 0x6 /**< LED0 output and brightness control byte 0 */
@@ -55,6 +55,7 @@ class Adafruit_PWMServoDriver {
   void wakeup();
   void setExtClk(uint8_t prescale);
   void setPWMFreq(float freq);
+  void setOutputMode(bool totempole);
   uint8_t getPWM(uint8_t num);
   void setPWM(uint8_t num, uint16_t on, uint16_t off);
   void setPin(uint8_t num, uint16_t val, bool invert=false);


### PR DESCRIPTION
The board is advertised as supporting both open drain and push-pull configurations for the output pins. 
This commit implements a method for setting the output mode to either open drain or push-pull/totempole. 

Besides the method the commit adds a define for the MODE2 register, which is required for setting the mode. 

The commit only adds a new method and should not interfere with any previous functionality.