### PR TITLE
Unbug Prescale calculation and update oscillator frequency handler

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -33,13 +33,29 @@
 /*!
  *  @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on a
  * TwoWire interface
- *  @param  addr The 7-bit I2C address to locate this chip, default is 0x40
- *  @param  i2c  A pointer to a 'Wire' compatible object that we'll use to
- * communicate with
  */
-Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(uint8_t addr, TwoWire *i2c) {
-  _i2c = i2c;
-  _i2caddr = addr;
+Adafruit_PWMServoDriver::Adafruit_PWMServoDriver():
+  _i2caddr(PCA9685_I2C_ADDRESS), _i2c(Wire) {
+}
+
+/*!
+ *  @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on a
+ * TwoWire interface
+ *  @param  addr The 7-bit I2C address to locate this chip, default is 0x40
+ */
+Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr):
+  _i2caddr(addr), _i2c(Wire) {
+}
+
+/*!
+ *  @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on a
+ * TwoWire interface
+ *  @param  addr The 7-bit I2C address to locate this chip, default is 0x40
+ *  @param  i2c  A reference to a 'TwoWire' object that we'll use to communicate
+ *  with
+ */
+Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr, TwoWire& i2c) :
+  _i2caddr(addr), _i2c(i2c) {
 }
 
 /*!
@@ -48,7 +64,7 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(uint8_t addr, TwoWire *i2c) {
  *          Sets External Clock (Optional)
  */
 void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
-  _i2c->begin();
+  _i2c.begin();
   reset();
   if (prescale) {
     setExtClk(prescale);
@@ -197,8 +213,8 @@ uint8_t Adafruit_PWMServoDriver::readPrescale(void)
  *  @return requested PWM output value
  */
 uint8_t Adafruit_PWMServoDriver::getPWM(uint8_t num) {
-  _i2c->requestFrom((int)_i2caddr, PCA9685_LED0_ON_L + 4 * num, (int)4);
-  return _i2c->read();
+  _i2c.requestFrom((int)_i2caddr, PCA9685_LED0_ON_L + 4 * num, (int)4);
+  return _i2c.read();
 }
 
 /*!
@@ -217,13 +233,13 @@ void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
   Serial.println(off);
 #endif
 
-  _i2c->beginTransmission(_i2caddr);
-  _i2c->write(PCA9685_LED0_ON_L + 4 * num);
-  _i2c->write(on);
-  _i2c->write(on >> 8);
-  _i2c->write(off);
-  _i2c->write(off >> 8);
-  _i2c->endTransmission();
+  _i2c.beginTransmission(_i2caddr);
+  _i2c.write(PCA9685_LED0_ON_L + 4 * num);
+  _i2c.write(on);
+  _i2c.write(on >> 8);
+  _i2c.write(off);
+  _i2c.write(off >> 8);
+  _i2c.endTransmission();
 }
 
 /*!
@@ -263,17 +279,17 @@ void Adafruit_PWMServoDriver::setPin(uint8_t num, uint16_t val, bool invert) {
 }
 
 uint8_t Adafruit_PWMServoDriver::read8(uint8_t addr) {
-  _i2c->beginTransmission(_i2caddr);
-  _i2c->write(addr);
-  _i2c->endTransmission();
+  _i2c.beginTransmission(_i2caddr);
+  _i2c.write(addr);
+  _i2c.endTransmission();
 
-  _i2c->requestFrom((uint8_t)_i2caddr, (uint8_t)1);
-  return _i2c->read();
+  _i2c.requestFrom((uint8_t)_i2caddr, (uint8_t)1);
+  return _i2c.read();
 }
 
 void Adafruit_PWMServoDriver::write8(uint8_t addr, uint8_t d) {
-  _i2c->beginTransmission(_i2caddr);
-  _i2c->write(addr);
-  _i2c->write(d);
-  _i2c->endTransmission();
+  _i2c.beginTransmission(_i2caddr);
+  _i2c.write(addr);
+  _i2c.write(d);
+  _i2c.endTransmission();
 }

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -200,7 +200,7 @@ void Adafruit_PWMServoDriver::setOutputMode(bool totempole) {
 
 /*!
  *  @brief  Reads set Prescale from PCA9685
- *  @param  void
+ *  @return prescale value
  */
 uint8_t Adafruit_PWMServoDriver::readPrescale(void)
 {

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -35,7 +35,7 @@
  * TwoWire interface
  */
 Adafruit_PWMServoDriver::Adafruit_PWMServoDriver():
-  _i2caddr(PCA9685_I2C_ADDRESS), _i2c(Wire) {
+  _i2caddr(PCA9685_I2C_ADDRESS), _i2c(&Wire) {
 }
 
 /*!
@@ -44,7 +44,7 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver():
  *  @param  addr The 7-bit I2C address to locate this chip, default is 0x40
  */
 Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr):
-  _i2caddr(addr), _i2c(Wire) {
+  _i2caddr(addr), _i2c(&Wire) {
 }
 
 /*!
@@ -55,7 +55,7 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr):
  *  with
  */
 Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr, TwoWire& i2c) :
-  _i2caddr(addr), _i2c(i2c) {
+  _i2caddr(addr), _i2c(&i2c) {
 }
 
 /*!
@@ -64,7 +64,7 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr, TwoWire& i2
  *          Sets External Clock (Optional)
  */
 void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
-  _i2c.begin();
+  _i2c->begin();
   reset();
   if (prescale) {
     setExtClk(prescale);
@@ -213,8 +213,8 @@ uint8_t Adafruit_PWMServoDriver::readPrescale(void)
  *  @return requested PWM output value
  */
 uint8_t Adafruit_PWMServoDriver::getPWM(uint8_t num) {
-  _i2c.requestFrom((int)_i2caddr, PCA9685_LED0_ON_L + 4 * num, (int)4);
-  return _i2c.read();
+  _i2c->requestFrom((int)_i2caddr, PCA9685_LED0_ON_L + 4 * num, (int)4);
+  return _i2c->read();
 }
 
 /*!
@@ -233,13 +233,13 @@ void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
   Serial.println(off);
 #endif
 
-  _i2c.beginTransmission(_i2caddr);
-  _i2c.write(PCA9685_LED0_ON_L + 4 * num);
-  _i2c.write(on);
-  _i2c.write(on >> 8);
-  _i2c.write(off);
-  _i2c.write(off >> 8);
-  _i2c.endTransmission();
+  _i2c->beginTransmission(_i2caddr);
+  _i2c->write(PCA9685_LED0_ON_L + 4 * num);
+  _i2c->write(on);
+  _i2c->write(on >> 8);
+  _i2c->write(off);
+  _i2c->write(off >> 8);
+  _i2c->endTransmission();
 }
 
 /*!
@@ -279,17 +279,17 @@ void Adafruit_PWMServoDriver::setPin(uint8_t num, uint16_t val, bool invert) {
 }
 
 uint8_t Adafruit_PWMServoDriver::read8(uint8_t addr) {
-  _i2c.beginTransmission(_i2caddr);
-  _i2c.write(addr);
-  _i2c.endTransmission();
+  _i2c->beginTransmission(_i2caddr);
+  _i2c->write(addr);
+  _i2c->endTransmission();
 
-  _i2c.requestFrom((uint8_t)_i2caddr, (uint8_t)1);
-  return _i2c.read();
+  _i2c->requestFrom((uint8_t)_i2caddr, (uint8_t)1);
+  return _i2c->read();
 }
 
 void Adafruit_PWMServoDriver::write8(uint8_t addr, uint8_t d) {
-  _i2c.beginTransmission(_i2caddr);
-  _i2c.write(addr);
-  _i2c.write(d);
-  _i2c.endTransmission();
+  _i2c->beginTransmission(_i2caddr);
+  _i2c->write(addr);
+  _i2c->write(d);
+  _i2c->endTransmission();
 }

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -91,7 +91,7 @@ class Adafruit_PWMServoDriver {
 
  private:
   uint8_t _i2caddr;
-  TwoWire& _i2c;
+  TwoWire* _i2c;
 
   uint8_t read8(uint8_t addr);
   void write8(uint8_t addr, uint8_t d);

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -28,10 +28,10 @@
 // REGISTER ADDRESSES
 #define PCA9685_MODE1        0x00 /**< Mode Register 1 */
 #define PCA9685_MODE2        0x01 /**< Mode Register 2 */
-#define PCA9685_SUBADR1      0x02 /**< i2c bus address 1 */
-#define PCA9685_SUBADR2      0x03 /**< i2c bus address 2 */
-#define PCA9685_SUBADR3      0x04 /**< i2c bus address 3 */
-#define PCA9685_ALLCALLADR   0x05
+#define PCA9685_SUBADR1      0x02 /**< I2C-bus subaddress 1 */
+#define PCA9685_SUBADR2      0x03 /**< I2C-bus subaddress 2 */
+#define PCA9685_SUBADR3      0x04 /**< I2C-bus subaddress 3 */
+#define PCA9685_ALLCALLADR   0x05 /**< LED All Call I2C-bus address */
 #define PCA9685_LED0_ON_L    0x06 /**< LED0 output and brightness control byte 0 */
 #define PCA9685_LED0_ON_H    0x07 /**< LED0 output and brightness control byte 1 */
 #define PCA9685_LED0_OFF_L   0x08 /**< LED0 output and brightness control byte 2 */
@@ -42,33 +42,32 @@
 #define PCA9685_ALLLED_OFF_L 0xFC /**< load all the LEDn_OFF registers, byte 0 */
 #define PCA9685_ALLLED_OFF_H 0xFD /**< load all the LEDn_OFF registers, byte 1 */
 #define PCA9685_PRESCALE     0xFE /**< Prescaler for PWM output frequency */
-#define PCA9685_TESTMODE     0xFF
+#define PCA9685_TESTMODE     0xFF /**< defines the test mode to be entered */
 
 // MODE1 bits
-#define MODE1_ALLCAL         0x01
-#define MODE1_SUB3           0x02
-#define MODE1_SUB2           0x04
-#define MODE1_SUB1           0x08
-#define MODE1_SLEEP          0x10
-#define MODE1_AI             0x20
-#define MODE1_EXTCLK         0x40
-#define MODE1_RESTART        0x80
+#define MODE1_ALLCAL         0x01 /**< respond to LED All Call I2C-bus address */
+#define MODE1_SUB3           0x02 /**< respond to I2C-bus subaddress 3 */
+#define MODE1_SUB2           0x04 /**< respond to I2C-bus subaddress 2 */
+#define MODE1_SUB1           0x08 /**< respond to I2C-bus subaddress 1 */
+#define MODE1_SLEEP          0x10 /**< Low power mode. Oscillator off */
+#define MODE1_AI             0x20 /**< Auto-Increment enabled */
+#define MODE1_EXTCLK         0x40 /**< Use EXTCLK pin clock */
+#define MODE1_RESTART        0x80 /**< Restart enabled */
 // MODE2 bits
-#define MODE2_OUTNE_0        0x01
-#define MODE2_OUTNE_1        0x02
-#define MODE2_OUTDRV         0x04
-#define MODE2_OCH            0x08
-#define MODE2_INVRT          0x10
+#define MODE2_OUTNE_0        0x01 /**< Active LOW output enable input */
+#define MODE2_OUTNE_1        0x02 /**< Active LOW output enable input - high impedience */
+#define MODE2_OUTDRV         0x04 /**< totem pole structure vs open-drain */
+#define MODE2_OCH            0x08 /**< Outputs change on ACK vs STOP */
+#define MODE2_INVRT          0x10 /**< Output logic state inverted */
 
-// Default PCA9685 I2C Slave Address if A0-A5 are not set
-#define PCA9685_I2C_ADDRESS  0x40
+#define PCA9685_I2C_ADDRESS  0x40 /**< Default PCA9685 I2C Slave Address */
 
-#define FREQUENCY_OSCILLATOR 25000000
-#define FREQUENCY_CALIBRATED 26075000 // measured 104.3% compared to official 25 MHz
-#define FREQUENCY_LEGACY     27777778 // Effect of freq /= 0,9
+#define FREQUENCY_OSCILLATOR 25000000 /**< Oscillator frequency cf satasheet */
+#define FREQUENCY_CALIBRATED 26075000 /**< Oscillator frequency measured at 104.3% */
+#define FREQUENCY_LEGACY     27777778 /**< Oscillator frequency using freq /= 0,9 */
 
-#define PCA9685_PRESCALE_MIN 3
-#define PCA9685_PRESCALE_MAX 255
+#define PCA9685_PRESCALE_MIN 3 /**< minimum prescale value */
+#define PCA9685_PRESCALE_MAX 255 /**< maximum prescale value */
 
 /*! 
  *  @brief  Class that stores state and functions for interacting with PCA9685 PWM chip

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -86,6 +86,7 @@ class Adafruit_PWMServoDriver {
   uint8_t getPWM(uint8_t num);
   void setPWM(uint8_t num, uint16_t on, uint16_t off);
   void setPin(uint8_t num, uint16_t val, bool invert=false);
+  uint8_t readPrescale(void);
 
  private:
   uint8_t _i2caddr;

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -25,30 +25,57 @@
 #include <Arduino.h>
 #include <Wire.h>
 
-#define PCA9685_SUBADR1 0x2 /**< i2c bus address 1 */
-#define PCA9685_SUBADR2 0x3 /**< i2c bus address 2 */
-#define PCA9685_SUBADR3 0x4 /**< i2c bus address 3 */
+// REGISTER ADDRESSES
+#define PCA9685_MODE1        0x00 /**< Mode Register 1 */
+#define PCA9685_MODE2        0x01 /**< Mode Register 2 */
+#define PCA9685_SUBADR1      0x02 /**< i2c bus address 1 */
+#define PCA9685_SUBADR2      0x03 /**< i2c bus address 2 */
+#define PCA9685_SUBADR3      0x04 /**< i2c bus address 3 */
+#define PCA9685_ALLCALLADR   0x05
+#define PCA9685_LED0_ON_L    0x06 /**< LED0 output and brightness control byte 0 */
+#define PCA9685_LED0_ON_H    0x07 /**< LED0 output and brightness control byte 1 */
+#define PCA9685_LED0_OFF_L   0x08 /**< LED0 output and brightness control byte 2 */
+#define PCA9685_LED0_OFF_H   0x09 /**< LED0 output and brightness control byte 3 */
+// etc all 16:  LED15_OFF_H 0x45
+#define PCA9685_ALLLED_ON_L  0xFA /**< load all the LEDn_ON registers, byte 0 */
+#define PCA9685_ALLLED_ON_H  0xFB /**< load all the LEDn_ON registers, byte 1 */
+#define PCA9685_ALLLED_OFF_L 0xFC /**< load all the LEDn_OFF registers, byte 0 */
+#define PCA9685_ALLLED_OFF_H 0xFD /**< load all the LEDn_OFF registers, byte 1 */
+#define PCA9685_PRESCALE     0xFE /**< Prescaler for PWM output frequency */
+#define PCA9685_TESTMODE     0xFF
 
-#define PCA9685_MODE1 0x0 /**< Mode Register 1 */
-#define PCA9685_MODE2 0x1 /**< Mode Register 2 */
-#define PCA9685_PRESCALE 0xFE /**< Prescaler for PWM output frequency */
+// MODE1 bits
+#define MODE1_ALLCAL         0x01
+#define MODE1_SUB3           0x02
+#define MODE1_SUB2           0x04
+#define MODE1_SUB1           0x08
+#define MODE1_SLEEP          0x10
+#define MODE1_AI             0x20
+#define MODE1_EXTCLK         0x40
+#define MODE1_RESTART        0x80
+// MODE2 bits
+#define MODE2_OUTNE_0        0x01
+#define MODE2_OUTNE_1        0x02
+#define MODE2_OUTDRV         0x04
+#define MODE2_OCH            0x08
+#define MODE2_INVRT          0x10
 
-#define LED0_ON_L 0x6 /**< LED0 output and brightness control byte 0 */
-#define LED0_ON_H 0x7 /**< LED0 output and brightness control byte 1 */
-#define LED0_OFF_L 0x8 /**< LED0 output and brightness control byte 2 */
-#define LED0_OFF_H 0x9 /**< LED0 output and brightness control byte 3 */
+// Default PCA9685 I2C Slave Address if A0-A5 are not set
+#define PCA9685_I2C_ADDRESS  0x40
 
-#define ALLLED_ON_L 0xFA /**< load all the LEDn_ON registers, byte 0 */
-#define ALLLED_ON_H 0xFB /**< load all the LEDn_ON registers, byte 1 */
-#define ALLLED_OFF_L 0xFC /**< load all the LEDn_OFF registers, byte 0 */
-#define ALLLED_OFF_H 0xFD /**< load all the LEDn_OFF registers, byte 1 */
+#define FREQUENCY_OSCILLATOR 25000000
+#define FREQUENCY_CALIBRATED 26075000 // measured 104.3% compared to official 25 MHz
+#define FREQUENCY_LEGACY     27777778 // Effect of freq /= 0,9
+
+#define PCA9685_PRESCALE_MIN 3
+#define PCA9685_PRESCALE_MAX 255
 
 /*! 
  *  @brief  Class that stores state and functions for interacting with PCA9685 PWM chip
  */
 class Adafruit_PWMServoDriver {
  public:
-  Adafruit_PWMServoDriver(uint8_t addr = 0x40, TwoWire *I2C = &Wire);
+  Adafruit_PWMServoDriver(uint8_t addr = PCA9685_I2C_ADDRESS, TwoWire *I2C = &Wire);
   void begin(uint8_t prescale = 0);
   void reset();
   void sleep();

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -75,7 +75,9 @@
  */
 class Adafruit_PWMServoDriver {
  public:
-  Adafruit_PWMServoDriver(uint8_t addr = PCA9685_I2C_ADDRESS, TwoWire *I2C = &Wire);
+  Adafruit_PWMServoDriver();
+  Adafruit_PWMServoDriver(const uint8_t addr);
+  Adafruit_PWMServoDriver(const uint8_t addr, TwoWire& i2c);
   void begin(uint8_t prescale = 0);
   void reset();
   void sleep();
@@ -90,8 +92,7 @@ class Adafruit_PWMServoDriver {
 
  private:
   uint8_t _i2caddr;
-  
-  TwoWire *_i2c;
+  TwoWire& _i2c;
 
   uint8_t read8(uint8_t addr);
   void write8(uint8_t addr, uint8_t d);

--- a/examples/gpiotest/gpiotest.ino
+++ b/examples/gpiotest/gpiotest.ino
@@ -24,7 +24,7 @@ Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 // you can also call it with a different address you want
 //Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
 // you can also call it with a different address and I2C interface
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, &Wire);
+//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
 
 void setup() {
   Serial.begin(9600);

--- a/examples/oscillator/oscillator.ino
+++ b/examples/oscillator/oscillator.ino
@@ -1,0 +1,129 @@
+/***************************************************
+  This is an example for our Adafruit 16-channel PWM & Servo driver
+  to calibrate the frequency of the oscillator clock of the PCA9685.
+
+  CAUTION: DO NOT CONNECT ANY VOLTAGE HIGHER THAN THE BOARD LIMITS.
+  For 3.3V boards, like the ESP8266, remove any 5V input. The setup will
+  feed the voltage back into the board to measure the frequency.
+  KABOEM, SMOKE if you use too much VOLTAGE.
+
+  Connect the PCA9685 with I2C (Ground, VCC, SCL, SCA) and apply
+  voltage on V+. See above not higher than board limits.
+  Connect the signal (yellow pin, PWM) of the PCA9685 to your board:
+  Default is pin 3, last of first block.
+  Default is pin 14 (of your ESP8266).
+
+  Formula for prescale to get the targetted frequency (=update_rate) is:
+  prescale = round ( osc_clock / 4096 * update_rate) - 1
+  rewritten: osc_clock = (prescale + 1) * 4096 * update_rate
+  We will measure the real update_rate to assert the real osc_clock.
+
+  ***************************************************/
+
+#include <Wire.h>
+#include <Adafruit_PWMServoDriver.h>
+
+// called this way, it uses the default address 0x40
+Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
+// you can also call it with a different address you want
+//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40);
+// you can also call it with a different address and I2C interface
+//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
+
+#if (defined(ESP8266) || defined(ESP32))
+
+// Applied frequency in the test: can be changed to get the optimal
+// oscillator calibration for your targetted frequency.
+#define FREQUENCY             50
+
+// CAUTION: ONLY CONNECT server and ESP WITHOUT 5V ON V+ or green breakout supply pins. Use 3.3V on V+
+#define PIN_SERVO_FEEDBACK     3 // Connect Yellow PWM pin, 3 = last on first block
+#define PIN_BOARD_FEEDBACK    14 // 14 => D5 on NodeMCU
+
+uint8_t prescale = 0;
+// loop
+#define INTERVAL   1000  // 1 sec
+int32_t lastEvaluation = 0;
+uint16_t frozenCounter = 0;
+uint16_t countDeviations = 0;
+
+uint32_t totalCounter = 0;
+uint32_t totalTime = 0;   // in millis
+uint32_t realOsciFreq = 0;
+uint32_t multiplier = 4096;
+
+// interrupt
+volatile uint16_t interruptCounter = 0;
+
+ICACHE_RAM_ATTR void handleInterrupt() {
+  interruptCounter++;
+}
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("PCA9685 Oscillator test");
+
+  // set PCA9685
+  pwm.begin();
+  pwm.setPWMFreq(FREQUENCY);             // Set some frequency
+  pwm.setPWM(PIN_SERVO_FEEDBACK,0,2048); // half of time high, half of time low
+  prescale = pwm.readPrescale();         // read prescale
+  Serial.printf("Target frequency: %u\n", FREQUENCY);
+  Serial.printf("Applied prescale: %u\n", prescale);
+
+  // prepare interrupt on ESP pin
+  pinMode(PIN_BOARD_FEEDBACK, INPUT);
+  attachInterrupt(digitalPinToInterrupt(PIN_BOARD_FEEDBACK), handleInterrupt, RISING);
+
+  // take a breath and reset to zero
+  delay(10);
+  interruptCounter = 0;
+  lastEvaluation = millis();
+}
+
+void loop() {
+  if (millis() - lastEvaluation > INTERVAL)
+  {
+    // first freeze counters and adjust for new round
+    frozenCounter = interruptCounter; // first freeze counter
+    interruptCounter -= frozenCounter;
+    lastEvaluation += INTERVAL;
+
+    totalCounter += frozenCounter;
+    totalTime += 1;
+
+    // only print deviations from targetted frequency
+    //if (frozenCounter != FREQUENCY)
+    {
+       multiplier = 4096;
+       realOsciFreq = (prescale + 1) * totalCounter; // first part calcutlation
+       // now follows an ugly hack to have maximum precision in 32 bits
+       while (((realOsciFreq & 0x80000000) == 0) && (multiplier != 1))
+       {
+          realOsciFreq <<= 1;
+          multiplier >>= 1;
+       }
+       realOsciFreq /= totalTime;
+       if (multiplier) realOsciFreq *= multiplier;
+
+       countDeviations++;
+       Serial.printf("%4u", countDeviations);
+       Serial.printf(" Timestamp: %4u ", totalTime);
+       Serial.printf(" Freq: %4u ", frozenCounter);
+       Serial.printf(" Counter: %6u ", totalCounter);
+       Serial.printf(" calc.osci.freq: %9u\n",realOsciFreq);
+    }
+  }
+
+}
+#else
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("PCA9685 Oscillator test");
+  Serial.println("yet not available for your board."); // please help adapt the code!
+}
+
+void loop() {}
+
+#endif // ESP8266/ESP32

--- a/examples/pwmtest/pwmtest.ino
+++ b/examples/pwmtest/pwmtest.ino
@@ -24,7 +24,7 @@ Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 // you can also call it with a different address you want
 //Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
 // you can also call it with a different address and I2C interface
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, &Wire);
+//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
 
 void setup() {
   Serial.begin(9600);

--- a/examples/servo/servo.ino
+++ b/examples/servo/servo.ino
@@ -25,7 +25,7 @@ Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 // you can also call it with a different address you want
 //Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
 // you can also call it with a different address and I2C interface
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, &Wire);
+//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
 
 // Depending on your servo make, the pulse width min and max may vary, you 
 // want these to be as small/large as possible without hitting the hard stop


### PR DESCRIPTION
**Scope of the change**
- This solves issues mentioned in #40 
- Improve prescale calculation: removed overflow error, comply to datasheet for rounding and use measured oscillator frequency correction.
- Add example so people can measure their own oscillator frequency.
- Add public function to the class to read set prescale.
- Transfer the magic numbers to the header file.
- Change pointer to Wire to reference in function, but store pointer, see #50 and #58 

**Limitations of this change**
It is known the internal oscillator is not exactly 25MHz, which is ok for driving leds, but other applications need more precise timing. I changed the current correction, "0,9", simulating 27,8MHz, to a more precise number. Users who compensated in their own code, might need to remove their compensation. 

Improvements, that would break the interface and thus demand prior considerations of the community, were left out. 

**Examples that can exercise modified code.**
An example is added to measure the oscillator frequency very precisely (for as far the internal millis() of the MCU is precise)
