### PR TITLE
Add keywords.txt for Arduino IDE’s syntax highlighter

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,26 @@
+#######################################
+# Classes, datatypes (KEYWORD1)
+#######################################
+
+Adafruit_PWMServoDriver	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+begin	KEYWORD2
+reset	KEYWORD2
+sleep	KEYWORD2
+wakeup	KEYWORD2
+setExtClk	KEYWORD2
+setPWMFreq	KEYWORD2
+setOutputMode	KEYWORD2
+getPWM	KEYWORD2
+setPWM	KEYWORD2
+setPin	KEYWORD2
+readPrescale	KEYWORD2
+writeMicroseconds	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################


### PR DESCRIPTION
- **Describe the scope of your change**
Add keywords.txt for Arduino IDE’s syntax highlighter

An explanation of keywords markup for Arduino IDE’s syntax highlighter
https://spencer.bliven.us/index.php/2012/01/18/arduino-ide-keywords/

A single tab is required between the name and the keyword identifier, it must be a tab to meet the Arduino IDE’s syntax highlighter's required formating.

- **Describe any known limitations with your change.**  
The library constants were not added as they have limited value in Arduino IDE’s syntax highlighter for an end-user.

- **Please run any tests or examples that can exercise your modified code.**
no tests or examples are needed as this just adds the Arduino IDE’s syntax highlighting