### PR TITLE
Refactored setting prescale, add setPrescale

### DIFF
--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -81,6 +81,7 @@ class Adafruit_PWMServoDriver {
   void reset();
   void sleep();
   void wakeup();
+  void setPrescale(uint8_t prescale, bool extclk=false);
   void setExtClk(uint8_t prescale);
   void setPWMFreq(float freq);
   void setOutputMode(bool totempole);

--- a/examples/pwmtest/pwmtest.ino
+++ b/examples/pwmtest/pwmtest.ino
@@ -32,6 +32,8 @@ void setup() {
 
   pwm.begin();
   pwm.setPWMFreq(1600);  // This is the maximum PWM frequency
+  // or as alternative set the prescale manual: freq = oscillator-Hz / 4096*(prescale+1)
+  pwm.setPrescale(0x1e);  // PCA9685 sets itself default to 0x1e, approx 200Hz
 
   // if you want to really speed stuff up, you can go into 'fast 400khz I2C' mode
   // some i2c devices dont like this so much so if you're sharing the bus, watch


### PR DESCRIPTION
**Scope**
Refactored the code for setting prescale which was in the code twice and moved it to a `void setPrescale(uint8_t prescale, bool extclk=false)` function.

**Known limitations**
A private setPrescale function could be preferred.

I refrained from changing the definition of existing functions, but considered
- The function begin(prescale) enables the external oscillator if prescale > 0. To my opinion this function should use a boolean. Also could be considered to move it to a separate `void setExternalOscillator(void)` function.
- The used oscillator frequency could be stored in a variable. So the frequency can be set once and used throughout the code, for example if an external oscillator different from 25MHz is used. Also people could choose to use 25MHz, 26MHz or what they seem reasonable for the real frequency of their device.
- I combined setting prescale and extclk as it needs the same steps. 

**Tests and examples**
In pwmtest.ino an example of setPrescale is added.
