### PR TITLE
Simplify and improve the writeMicroseconds() calculations

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -296,24 +296,14 @@ void Adafruit_PWMServoDriver::writeMicroseconds(uint8_t num, uint16_t Microsecon
   double pulselength;
   pulselength = 1000000;   // 1,000,000 us per second
 
-  // Read prescale and convert to frequency
+  // Read prescale
   double prescale = Adafruit_PWMServoDriver::readPrescale();
+  Serial.print(prescale); Serial.println(" PCA9685 chip prescale");
+
+  // Calculate the pulse for PWM based on Equation 1 from the datasheet section 7.3.5
   prescale += 1;
-  uint32_t freq = 25000000; // Chip frequency is 25MHz
-  freq /= prescale;
-  freq /= 4096; // 12 bits of resolution
- 
-  #ifdef ENABLE_DEBUG_OUTPUT
-  Serial.print(freq); Serial.println(" Calculated PCA9685 chip PWM Frequency");
-  #endif
-  
-  pulselength /= freq;   //  us per period from PCA9685 chip PWM Frequency using prescale reverse frequency calc
-
-  #ifdef ENABLE_DEBUG_OUTPUT
-  Serial.print(pulselength); Serial.println(" us per period");
-  #endif
-
-  pulselength /= 4096;  // 12 bits of resolution
+  pulselength *= prescale; 
+  pulselength /= FREQUENCY_CALIBRATED;
 
   #ifdef ENABLE_DEBUG_OUTPUT
   Serial.print(pulselength); Serial.println(" us per bit"); 

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -298,7 +298,10 @@ void Adafruit_PWMServoDriver::writeMicroseconds(uint8_t num, uint16_t Microsecon
 
   // Read prescale
   double prescale = Adafruit_PWMServoDriver::readPrescale();
+
+  #ifdef ENABLE_DEBUG_OUTPUT
   Serial.print(prescale); Serial.println(" PCA9685 chip prescale");
+  #endif
 
   // Calculate the pulse for PWM based on Equation 1 from the datasheet section 7.3.5
   prescale += 1;

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -297,7 +297,7 @@ void Adafruit_PWMServoDriver::writeMicroseconds(uint8_t num, uint16_t Microsecon
   pulselength = 1000000;   // 1,000,000 us per second
 
   // Read prescale
-  double prescale = Adafruit_PWMServoDriver::readPrescale();
+  uint16_t prescale = Adafruit_PWMServoDriver::readPrescale();
 
   #ifdef ENABLE_DEBUG_OUTPUT
   Serial.print(prescale); Serial.println(" PCA9685 chip prescale");


### PR DESCRIPTION
- **Describe the scope of your change**
Overall this change makes less calculation steps, and uses fewer variables. The change should be faster and more accurate to the intended results.

Checked the calculations by hand

Use Datasheet 7.3.5 Equation 1 for frequency from prescale
https://cdn-shop.adafruit.com/datasheets/PCA9685.pdf
Frequency = (ClockFrequency/(PreScale+1))*(1/BitRate)
and from the rest of the calculation
us per period = PulseLength/Frequency
us per bit = us per period/BitRate
 we can combine to get
us per bit = (PulseLength/((ClockFrequency/(PreScale+1))*(1/BitRate)))*(1/BitRate)

This can be simplified to (PulseLength (PreScale + 1))/ClockFrequency 
this formula was implemented in proposed code

checked by setting chip frequency to 60Hz
read prescale = 105
us per bit = 4.069 with 25Mhz (a PWM frequency of about 57.58hz)
Choosing the FREQUENCY_CALIBRATED constant listed at 104.3% higher or 26.075MHz
we get 
us per bit = 4.1035 or a PWM frequency of about 60.056Hz much closer to the set 60Hz 

Overall this change makes less calculation steps, and uses fewer variables. The change should be faster and more accurate to the intended results.

- **Describe any known limitations with your change.**  
  - Output is not precise due to the calculations involved (same as the example servo sketch's `setServoPulse()` method)

- **Please run any tests or examples that can exercise your modified code.**  
Calculations were checked by hand and are an improvement