### PR TITLE
Add new functions from v2.2.0 to the Keywords

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -20,7 +20,10 @@ setPWM	KEYWORD2
 setPin	KEYWORD2
 readPrescale	KEYWORD2
 writeMicroseconds	KEYWORD2
+setOscillatorFrequency	KEYWORD2
+getOscillatorFrequency	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
+FREQUENCY_OSCILLATOR  LITERAL1


### PR DESCRIPTION
- **Describe the scope of your change**
Adds the following to the Keywords for Arduino syntax highlighting
- setOscillatorFrequency
- getOscillatorFrequency
- FREQUENCY_OSCILLATOR

- **Describe any known limitations with your change.**  
All library constants are not included

- **Please run any tests or examples that can exercise your modified code.**
Tests are not needed as this is only syntax highlighting,
Files like this should be inspected to ensure that only a single tab is used between the keyword and the constant identifier