### PR TITLE
Correct Servo frequency to 50 Hz

### DIFF
--- a/examples/servo/servo.ino
+++ b/examples/servo/servo.ino
@@ -35,7 +35,7 @@ Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 #define SERVOMAX  600 // This is the 'maximum' pulse length count (out of 4096)
 #define USMIN  600 // This is the rounded 'minimum' microsecond length based on the minimum pulse of 150
 #define USMAX  2400 // This is the rounded 'maximum' microsecond length based on the maximum pulse of 600
-#define SERVO_FREQ 60 // Analog servos run at ~60 Hz updates
+#define SERVO_FREQ 50 // Analog servos run at ~50 Hz updates
 
 // our servo # counter
 uint8_t servonum = 0;

--- a/examples/servo/servo.ino
+++ b/examples/servo/servo.ino
@@ -49,7 +49,7 @@ void setup() {
   // that precise. You can 'calibrate' by tweaking this number till
   // you get the frequency you're expecting!
   pwm.setOscillatorFrequency(27000000);  // The int.osc. is closer to 27MHz  
-  pwm.setPWMFreq(SERVO_FREQ);  // Analog servos run at ~60 Hz updates
+  pwm.setPWMFreq(SERVO_FREQ);  // Analog servos run at ~50 Hz updates
 
   delay(10);
 }


### PR DESCRIPTION
Library incorrectly listed and used the update frequency for analog servos as 60 Hz, see references verifying analog servos should be run at 50 Hz updates

- https://dronebotworkshop.com/servo-motors-with-arduino/
  - "In a conventional analog servo motor a PWM signal with a period of 20 ms is used to control the motors. A signal of 20 ms has a frequency of 50 Hz."
- https://en.wikipedia.org/wiki/Servo_control#Pulse_duration
  - The period of 20 ms (50 Hz) comes from the days where the signal was encoded in PPM (pulse position modulation) 
- Typical RC servo frequency is 50 Hz
  - see sg90 datasheet http://www.ee.ic.ac.uk/pcheung/teaching/DE1_EE/stores/sg90_datasheet.pdf