### PR TITLE
SDA + SCL: pin customization

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -64,7 +64,24 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr,
  *          Sets External Clock (Optional)
  */
 void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
-  _i2c->begin();
+  begin(0,0, prescale);
+}
+
+
+/*!
+ *  @brief  Setups the I2C interface and hardware
+ *  @param  sda  Override default SDA pin
+ *  @param  scl  Override default SCL pin
+ *  @param  prescale  Sets External Clock (Optional)
+ */
+void Adafruit_PWMServoDriver::begin(uint8_t sda, uint8_t scl, uint8_t prescale) {
+  
+  if (sda && scl) {
+    _i2c->begin(sda, scl);
+  } else {
+    _i2c->begin();
+  }    
+  
   reset();
   if (prescale) {
     setExtClk(prescale);
@@ -75,6 +92,7 @@ void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   // set the default internal frequency
   setOscillatorFrequency(FREQUENCY_OSCILLATOR);
 }
+
 
 /*!
  *  @brief  Sends a reset command to the PCA9685 chip over I2C

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -78,6 +78,7 @@ public:
   Adafruit_PWMServoDriver(const uint8_t addr);
   Adafruit_PWMServoDriver(const uint8_t addr, TwoWire &i2c);
   void begin(uint8_t prescale = 0);
+  void begin(uint8_t sda, uint8_t scl, uint8_t prescale = 0);
   void reset();
   void sleep();
   void wakeup();


### PR DESCRIPTION
**Motivation**
This change was motivated by the incompatibility of ESP32-CAM hardware, which has no exposed sda / scl pins:

**Changes**
- Added sda and scl parameters for the `begin `method.
- Compatibility is maintained

**Tests**
- `pwm.begin(255); //prescale` - **OK**
- `pwm.begin(2,14); //2=SDA, 14=SCL` - **OK**
- `pwm.begin(2,14, 255); //2=SDA, 14=SCL, 255=prescale` - **OK**
- `pwm.begin();` - **OK**

 