### PR TITLE
Update Adafruit_PWMServoDriver.cpp

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -66,14 +66,16 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr,
 void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   _i2c->begin();
   reset();
+    
+  // set the default internal frequency
+  setOscillatorFrequency(FREQUENCY_OSCILLATOR);
+    
   if (prescale) {
     setExtClk(prescale);
   } else {
     // set a default frequency
     setPWMFreq(1000);
   }
-  // set the default internal frequency
-  setOscillatorFrequency(FREQUENCY_OSCILLATOR);
 }
 
 /*!


### PR DESCRIPTION
Change:
_oscillator frequency used in setting the PWM frequency is initialized as 0 and thus not used in the setPWMFreq on begin.

I found that the oscillator frequency variable used in the calculation of the pwm frequency is not properly set in the begin statement. This means the user has to use another setPWMFreq call to set the pwm frequency after begin has been called.

Just a small edit that shouldn't impact user code too much. The default frequency is 200Hz (default prescale register value) in comparison to the 1000Hz stated in the begin method, so if the user didn't call an extra setPWMFreq before and was dependent on the 200Hz this will break some things. An option to fix this could be to set the default in the begin method to 200Hz also but defeats the purpose of the code setting it currently to 1000Hz

