### PR TITLE
Update Adafruit_PWMServoDriver.cpp

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -66,14 +66,17 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr,
 void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   _i2c->begin();
   reset();
+    
+    // set the default internal frequency
+  setOscillatorFrequency(FREQUENCY_OSCILLATOR);
+    
   if (prescale) {
     setExtClk(prescale);
   } else {
     // set a default frequency
     setPWMFreq(1000);
   }
-  // set the default internal frequency
-  setOscillatorFrequency(FREQUENCY_OSCILLATOR);
+
 }
 
 /*!


### PR DESCRIPTION
The FREQUENCY_OSCILLATOR is required by the function setPWMFreq(). Therefore, the FREQUENCY_OSCILLATOR must be set before call the function setPWMFreq()
