### PR TITLE
Replaced faulty getPWM with getPWMOn and getPWMOn.

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -204,13 +204,39 @@ uint8_t Adafruit_PWMServoDriver::readPrescale(void) {
 }
 
 /*!
- *  @brief  Gets the PWM output of one of the PCA9685 pins
- *  @param  num One of the PWM output pins, from 0 to 15
- *  @return requested PWM output value
+ *  @brief  Gets the PWM phase start of one of the PCA9685 pins
+ *  @param  channel One of the PWM output pins, from 0 to 15
+ *  @return Requested PWM output phase start
  */
-uint8_t Adafruit_PWMServoDriver::getPWM(uint8_t num) {
-  _i2c->requestFrom((int)_i2caddr, PCA9685_LED0_ON_L + 4 * num, (int)4);
-  return _i2c->read();
+uint16_t Adafruit_PWMServoDriver::getPWMOn(uint8_t channel) {
+	byte regAddress = PCA9685_LED0_ON_L + (channel << 2);
+	_i2c->beginTransmission(_i2caddr);
+	_i2c->write(regAddress);
+	_i2c->endTransmission();
+
+	_i2c->requestFrom((uint8_t)_i2caddr, (uint8_t)2);
+	uint16_t value = (uint16_t)_i2c->read();
+	value |= (uint16_t)(_i2c->read() << 8);
+
+	return value;
+}
+
+/*!
+ *  @brief  Gets the PWM phase end of one of the PCA9685 pins
+ *  @param  channel One of the PWM output pins, from 0 to 15
+ *  @return Requested PWM output phase end
+ */
+uint16_t Adafruit_PWMServoDriver::getPWMOff(uint8_t channel) {
+	byte regAddress = PCA9685_LED0_OFF_L + (channel << 2);
+	_i2c->beginTransmission(_i2caddr);
+	_i2c->write(regAddress);
+	_i2c->endTransmission();
+
+	_i2c->requestFrom((uint8_t)_i2caddr, (uint8_t)2);
+	uint16_t value = (uint16_t)_i2c->read();
+	value |= (uint16_t)(_i2c->read() << 8);
+
+	return value;
 }
 
 /*!

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -84,7 +84,8 @@ public:
   void setExtClk(uint8_t prescale);
   void setPWMFreq(float freq);
   void setOutputMode(bool totempole);
-  uint8_t getPWM(uint8_t num);
+  uint16_t getPWMOn(uint8_t channel);
+  uint16_t getPWMOff(uint8_t channel);
   uint8_t setPWM(uint8_t num, uint16_t on, uint16_t off);
   void setPin(uint8_t num, uint16_t val, bool invert = false);
   uint8_t readPrescale(void);


### PR DESCRIPTION
The existing getPWM implementation always returned 0.  This implementation is based on the datasheet for the PCA9685 and examples found on the web.   It uses two methods instead of one -- one for the range start and one for the range end.  I'm currently using it in a personal project and the returned values are equal to the values I provide for setPWM.