### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -61,6 +61,7 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr,
  *  @brief  Setups the I2C interface and hardware
  *  @param  prescale
  *          Sets External Clock (Optional)
+ *  @return true if successful, otherwise false
  */
 bool Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   if (i2c_dev)

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -62,11 +62,12 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr,
  *  @param  prescale
  *          Sets External Clock (Optional)
  */
-void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
+bool Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   if (i2c_dev)
     delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(_i2caddr, _i2c);
-  i2c_dev->begin();
+  if (!i2c_dev->begin())
+    return false;
   reset();
   if (prescale) {
     setExtClk(prescale);
@@ -76,6 +77,8 @@ void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   }
   // set the default internal frequency
   setOscillatorFrequency(FREQUENCY_OSCILLATOR);
+
+  return true;
 }
 
 /*!

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -28,7 +28,6 @@
  */
 
 #include "Adafruit_PWMServoDriver.h"
-#include <Wire.h>
 
 //#define ENABLE_DEBUG_OUTPUT
 
@@ -64,7 +63,10 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr,
  *          Sets External Clock (Optional)
  */
 void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
-  _i2c->begin();
+  if (i2c_dev)
+    delete i2c_dev;
+  i2c_dev = new Adafruit_I2CDevice(_i2caddr, _i2c);
+  i2c_dev->begin();
   reset();
   if (prescale) {
     setExtClk(prescale);
@@ -206,11 +208,15 @@ uint8_t Adafruit_PWMServoDriver::readPrescale(void) {
 /*!
  *  @brief  Gets the PWM output of one of the PCA9685 pins
  *  @param  num One of the PWM output pins, from 0 to 15
+ *  @param  off If true, returns PWM OFF value, otherwise PWM ON
  *  @return requested PWM output value
  */
-uint8_t Adafruit_PWMServoDriver::getPWM(uint8_t num) {
-  _i2c->requestFrom((int)_i2caddr, PCA9685_LED0_ON_L + 4 * num, (int)4);
-  return _i2c->read();
+uint16_t Adafruit_PWMServoDriver::getPWM(uint8_t num, bool off) {
+  uint8_t buffer[2] = {uint8_t(PCA9685_LED0_ON_L + 4 * num), 0};
+  if (off)
+    buffer[0] += 2;
+  i2c_dev->write_then_read(buffer, 1, buffer, 2);
+  return uint16_t(buffer[0]) | (uint16_t(buffer[1]) << 8);
 }
 
 /*!
@@ -231,13 +237,15 @@ uint8_t Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on,
   Serial.println(off);
 #endif
 
-  _i2c->beginTransmission(_i2caddr);
-  _i2c->write(PCA9685_LED0_ON_L + 4 * num);
-  _i2c->write(on);
-  _i2c->write(on >> 8);
-  _i2c->write(off);
-  _i2c->write(off >> 8);
-  return _i2c->endTransmission();
+  uint8_t buffer[5];
+  buffer[0] = PCA9685_LED0_ON_L + 4 * num;
+  buffer[1] = on;
+  buffer[2] = on >> 8;
+  buffer[3] = off;
+  buffer[4] = off >> 8;
+  i2c_dev->write(buffer, 5);
+
+  return 0;
 }
 
 /*!
@@ -346,17 +354,12 @@ void Adafruit_PWMServoDriver::setOscillatorFrequency(uint32_t freq) {
 
 /******************* Low level I2C interface */
 uint8_t Adafruit_PWMServoDriver::read8(uint8_t addr) {
-  _i2c->beginTransmission(_i2caddr);
-  _i2c->write(addr);
-  _i2c->endTransmission();
-
-  _i2c->requestFrom((uint8_t)_i2caddr, (uint8_t)1);
-  return _i2c->read();
+  uint8_t buffer[1] = {addr};
+  i2c_dev->write_then_read(buffer, 1, buffer, 1);
+  return buffer[0];
 }
 
 void Adafruit_PWMServoDriver::write8(uint8_t addr, uint8_t d) {
-  _i2c->beginTransmission(_i2caddr);
-  _i2c->write(addr);
-  _i2c->write(d);
-  _i2c->endTransmission();
+  uint8_t buffer[2] = {addr, d};
+  i2c_dev->write(buffer, 2);
 }

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -77,7 +77,7 @@ public:
   Adafruit_PWMServoDriver();
   Adafruit_PWMServoDriver(const uint8_t addr);
   Adafruit_PWMServoDriver(const uint8_t addr, TwoWire &i2c);
-  void begin(uint8_t prescale = 0);
+  bool begin(uint8_t prescale = 0);
   void reset();
   void sleep();
   void wakeup();

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -23,8 +23,8 @@
 #ifndef _ADAFRUIT_PWMServoDriver_H
 #define _ADAFRUIT_PWMServoDriver_H
 
+#include <Adafruit_I2CDevice.h>
 #include <Arduino.h>
-#include <Wire.h>
 
 // REGISTER ADDRESSES
 #define PCA9685_MODE1 0x00      /**< Mode Register 1 */
@@ -84,7 +84,7 @@ public:
   void setExtClk(uint8_t prescale);
   void setPWMFreq(float freq);
   void setOutputMode(bool totempole);
-  uint8_t getPWM(uint8_t num);
+  uint16_t getPWM(uint8_t num, bool off = false);
   uint8_t setPWM(uint8_t num, uint16_t on, uint16_t off);
   void setPin(uint8_t num, uint16_t val, bool invert = false);
   uint8_t readPrescale(void);
@@ -96,6 +96,7 @@ public:
 private:
   uint8_t _i2caddr;
   TwoWire *_i2c;
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
 
   uint32_t _oscillator_freq;
   uint8_t read8(uint8_t addr);

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Adafruit PWM Servo Driver Library
 category=Device Control
 url=https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library
 architectures=*
+depends=Adafruit BusIO


### PR DESCRIPTION
For #91. Converts to BusIO usage. Also provides a fix for `getPWM()` which was broken.

Tested with `servo` example sketch which works same as before.

Also tested with this sketch to verify `getPWM()`:
```cpp
#include <Adafruit_PWMServoDriver.h>

#define SERVOMIN  200 // This is the 'minimum' pulse length count (out of 4096)
#define SERVOMAX  400 // This is the 'maximum' pulse length count (out of 4096)
#define SERVO_FREQ 50 // Analog servos run at ~50 Hz updates

Adafruit_PWMServoDriver pwm;

void setup() {
  Serial.begin(9600);
  while (!Serial);

  // init
  pwm.begin();
  pwm.setOscillatorFrequency(27000000);
  pwm.setPWMFreq(SERVO_FREQ);

  // set/read tests for PWM
  pwm.setPWM(0, 0, SERVOMIN);
  Serial.print("SERVOMIN = "); Serial.println(SERVOMIN);
  Serial.print("PWM ON = "); Serial.println(pwm.getPWM(0));
  Serial.print("PWM OFF = "); Serial.println(pwm.getPWM(0, true));

  pwm.setPWM(0, 0, SERVOMAX);
  Serial.print("SERVOMAX = "); Serial.println(SERVOMAX);
  Serial.print("PWM ON = "); Serial.println(pwm.getPWM(0));
  Serial.print("PWM OFF = "); Serial.println(pwm.getPWM(0, true));  

}

void loop() {
  pwm.setPWM(0, 0, SERVOMIN);
  delay(500);
  pwm.setPWM(0, 0, SERVOMAX);
  delay(500);
}
```

which outputs:
```
SERVOMIN = 200
PWM ON = 0
PWM OFF = 200
SERVOMAX = 400
PWM ON = 0
PWM OFF = 400
```