### PR TITLE
Move setOscillatorFrequency() call in begin()

### DIFF
--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -70,14 +70,16 @@ bool Adafruit_PWMServoDriver::begin(uint8_t prescale) {
   if (!i2c_dev->begin())
     return false;
   reset();
+
+  // set the default internal frequency
+  setOscillatorFrequency(FREQUENCY_OSCILLATOR);
+
   if (prescale) {
     setExtClk(prescale);
   } else {
     // set a default frequency
     setPWMFreq(1000);
   }
-  // set the default internal frequency
-  setOscillatorFrequency(FREQUENCY_OSCILLATOR);
 
   return true;
 }


### PR DESCRIPTION
This is a simple bug/fix. Just needed to change the order some methods were called. A couple of other PR's attempted this: #80 and #81

Tested using the `servo` example from this library.