### PR TITLE
Add `setMultiplePWM()` function

### DIFF
--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -86,6 +86,7 @@ public:
   void setOutputMode(bool totempole);
   uint16_t getPWM(uint8_t num, bool off = false);
   uint8_t setPWM(uint8_t num, uint16_t on, uint16_t off);
+  uint8_t setMultiplePWM(uint16_t *values, uint8_t length);
   void setPin(uint8_t num, uint16_t val, bool invert = false);
   uint8_t readPrescale(void);
   void writeMicroseconds(uint8_t num, uint16_t Microseconds);

--- a/examples/pwmtest/pwmtest.ino
+++ b/examples/pwmtest/pwmtest.ino
@@ -58,10 +58,12 @@ void setup() {
 
 void loop() {
   // Drive each PWM in a 'wave'
-  for (uint16_t i=0; i<4096; i += 8) {
-    for (uint8_t pwmnum=0; pwmnum < 16; pwmnum++) {
-      pwm.setPWM(pwmnum, 0, (i + (4096/16)*pwmnum) % 4096 );
+  uint16_t pwmValues[16];
+  for (uint16_t i = 0; i < 4096; i += 8) {
+    for (uint8_t pwmnum = 0; pwmnum < 16; pwmnum++) {
+      pwmValues[pwmnum] = (i + (4096 / 16) * pwmnum) % 4096;
     }
+    pwm.setMultiplePWM(pwmValues, 16);
 #ifdef ESP8266
     yield();  // take a breather, required for ESP8266
 #endif

--- a/keywords.txt
+++ b/keywords.txt
@@ -17,6 +17,7 @@ setPWMFreq	KEYWORD2
 setOutputMode	KEYWORD2
 getPWM	KEYWORD2
 setPWM	KEYWORD2
+setMultiplePWM KEYWORD2
 setPin	KEYWORD2
 readPrescale	KEYWORD2
 writeMicroseconds	KEYWORD2


### PR DESCRIPTION
# Purpose
Having to update up to 16 servo takes a long time as each update needs to start and end an I2C transmission.
The function `setMultiplePWM` allows for bulk update of pwm values. 

## Description

The function creates and populates a buffer with pwm settings for multiple channels before sending it in one I2C transmission.

**Scope**
- This addition does not change existing functionality, but adds a new function to the library.

**Examples**
- The example `pwmtest.ino` is a great example of the use case