### PR TITLE
Add clang-format CI job and apply formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 80
+AllowShortBlocksOnASingleLine: Always
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Attach
+DerivePointerAlignment: false
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 1

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -3,8 +3,18 @@ name: Arduino Library CI
 on: [pull_request, push, repository_dispatch]
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: clang-format check (v18)
+      run: |
+        find . -type f \( -name '*.cpp' -o -name '*.c' -o -name '*.h' \) \
+          ! -path './ci/*' ! -path './bin/*' | xargs clang-format-18 --dry-run --Werror
+
   build:
     runs-on: ubuntu-latest
+    needs: clang-format
 
     steps:
     - uses: actions/setup-python@v4

--- a/Adafruit_PWMServoDriver.cpp
+++ b/Adafruit_PWMServoDriver.cpp
@@ -29,7 +29,7 @@
 
 #include "Adafruit_PWMServoDriver.h"
 
-//#define ENABLE_DEBUG_OUTPUT
+// #define ENABLE_DEBUG_OUTPUT
 
 /*!
  *  @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on a
@@ -54,7 +54,7 @@ Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr)
  *  with
  */
 Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr,
-                                                 TwoWire &i2c)
+                                                 TwoWire& i2c)
     : _i2caddr(addr), _i2c(&i2c) {}
 
 /*!

--- a/Adafruit_PWMServoDriver.h
+++ b/Adafruit_PWMServoDriver.h
@@ -56,7 +56,7 @@
 #define MODE1_RESTART 0x80 /**< Restart enabled */
 // MODE2 bits
 #define MODE2_OUTNE_0 0x01 /**< Active LOW output enable input */
-#define MODE2_OUTNE_1                                                          \
+#define MODE2_OUTNE_1 \
   0x02 /**< Active LOW output enable input - high impedience */
 #define MODE2_OUTDRV 0x04 /**< totem pole structure vs open-drain */
 #define MODE2_OCH 0x08    /**< Outputs change on ACK vs STOP */
@@ -73,10 +73,10 @@
  * PWM chip
  */
 class Adafruit_PWMServoDriver {
-public:
+ public:
   Adafruit_PWMServoDriver();
   Adafruit_PWMServoDriver(const uint8_t addr);
-  Adafruit_PWMServoDriver(const uint8_t addr, TwoWire &i2c);
+  Adafruit_PWMServoDriver(const uint8_t addr, TwoWire& i2c);
   bool begin(uint8_t prescale = 0);
   void reset();
   void sleep();
@@ -93,10 +93,10 @@ public:
   void setOscillatorFrequency(uint32_t freq);
   uint32_t getOscillatorFrequency(void);
 
-private:
+ private:
   uint8_t _i2caddr;
-  TwoWire *_i2c;
-  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
+  TwoWire* _i2c;
+  Adafruit_I2CDevice* i2c_dev = NULL; ///< Pointer to I2C bus interface
 
   uint32_t _oscillator_freq;
   uint8_t read8(uint8_t addr);

--- a/examples/gpiotest/gpiotest.ino
+++ b/examples/gpiotest/gpiotest.ino
@@ -1,49 +1,50 @@
-/*************************************************** 
+/***************************************************
   This is an example for our Adafruit 16-channel PWM & Servo driver
   GPIO test - this will set a pin high/low
 
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/815
 
-  These drivers use I2C to communicate, 2 pins are required to  
+  These drivers use I2C to communicate, 2 pins are required to
   interface.
 
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Wire.h>
 #include <Adafruit_PWMServoDriver.h>
+#include <Wire.h>
 
 // called this way, it uses the default address 0x40
 Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 // you can also call it with a different address you want
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
+// Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
 // you can also call it with a different address and I2C interface
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
+// Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
 
 void setup() {
   Serial.begin(9600);
   Serial.println("GPIO test!");
 
   pwm.begin();
-  pwm.setPWMFreq(1000);  // Set to whatever you like, we don't use it in this demo!
+  pwm.setPWMFreq(
+      1000); // Set to whatever you like, we don't use it in this demo!
 
-  // if you want to really speed stuff up, you can go into 'fast 400khz I2C' mode
-  // some i2c devices dont like this so much so if you're sharing the bus, watch
-  // out for this!
+  // if you want to really speed stuff up, you can go into 'fast 400khz I2C'
+  // mode some i2c devices dont like this so much so if you're sharing the bus,
+  // watch out for this!
   Wire.setClock(400000);
 }
 
 void loop() {
   // Drive each pin in a 'wave'
-  for (uint8_t pin=0; pin<16; pin++) {
-    pwm.setPWM(pin, 4096, 0);       // turns pin fully on
+  for (uint8_t pin = 0; pin < 16; pin++) {
+    pwm.setPWM(pin, 4096, 0); // turns pin fully on
     delay(100);
-    pwm.setPWM(pin, 0, 4096);       // turns pin fully off
+    pwm.setPWM(pin, 0, 4096); // turns pin fully off
   }
 }

--- a/examples/oscillator/oscillator.ino
+++ b/examples/oscillator/oscillator.ino
@@ -20,35 +20,36 @@
 
   ***************************************************/
 
-#include <Wire.h>
 #include <Adafruit_PWMServoDriver.h>
+#include <Wire.h>
 
 // called this way, it uses the default address 0x40
 Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
 // you can also call it with a different address you want
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40);
+// Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40);
 // you can also call it with a different address and I2C interface
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
+// Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
 
 #if (defined(ESP8266) || defined(ESP32))
 
 // Applied frequency in the test: can be changed to get the optimal
 // oscillator calibration for your targetted frequency.
-#define FREQUENCY             50
+#define FREQUENCY 50
 
-// CAUTION: ONLY CONNECT server and ESP WITHOUT 5V ON V+ or green breakout supply pins. Use 3.3V on V+
-#define PIN_SERVO_FEEDBACK     3 // Connect Yellow PWM pin, 3 = last on first block
-#define PIN_BOARD_FEEDBACK    14 // 14 => D5 on NodeMCU
+// CAUTION: ONLY CONNECT server and ESP WITHOUT 5V ON V+ or green breakout
+// supply pins. Use 3.3V on V+
+#define PIN_SERVO_FEEDBACK 3  // Connect Yellow PWM pin, 3 = last on first block
+#define PIN_BOARD_FEEDBACK 14 // 14 => D5 on NodeMCU
 
 uint8_t prescale = 0;
 // loop
-#define INTERVAL   1000  // 1 sec
+#define INTERVAL 1000 // 1 sec
 int32_t lastEvaluation = 0;
 uint16_t frozenCounter = 0;
 uint16_t countDeviations = 0;
 
 uint32_t totalCounter = 0;
-uint32_t totalTime = 0;   // in millis
+uint32_t totalTime = 0; // in millis
 uint32_t realOsciFreq = 0;
 uint32_t multiplier = 4096;
 
@@ -65,15 +66,17 @@ void setup() {
 
   // set PCA9685
   pwm.begin();
-  pwm.setPWMFreq(FREQUENCY);             // Set some frequency
-  pwm.setPWM(PIN_SERVO_FEEDBACK,0,2048); // half of time high, half of time low
-  prescale = pwm.readPrescale();         // read prescale
+  pwm.setPWMFreq(FREQUENCY); // Set some frequency
+  pwm.setPWM(PIN_SERVO_FEEDBACK, 0,
+             2048);              // half of time high, half of time low
+  prescale = pwm.readPrescale(); // read prescale
   Serial.printf("Target frequency: %u\n", FREQUENCY);
   Serial.printf("Applied prescale: %u\n", prescale);
 
   // prepare interrupt on ESP pin
   pinMode(PIN_BOARD_FEEDBACK, INPUT);
-  attachInterrupt(digitalPinToInterrupt(PIN_BOARD_FEEDBACK), handleInterrupt, RISING);
+  attachInterrupt(digitalPinToInterrupt(PIN_BOARD_FEEDBACK), handleInterrupt,
+                  RISING);
 
   // take a breath and reset to zero
   delay(10);
@@ -82,8 +85,7 @@ void setup() {
 }
 
 void loop() {
-  if (millis() - lastEvaluation > INTERVAL)
-  {
+  if (millis() - lastEvaluation > INTERVAL) {
     // first freeze counters and adjust for new round
     frozenCounter = interruptCounter; // first freeze counter
     interruptCounter = interruptCounter - frozenCounter;
@@ -93,35 +95,35 @@ void loop() {
     totalTime += 1;
 
     // only print deviations from targetted frequency
-    //if (frozenCounter != FREQUENCY)
+    // if (frozenCounter != FREQUENCY)
     {
-       multiplier = 4096;
-       realOsciFreq = (prescale + 1) * totalCounter; // first part calcutlation
-       // now follows an ugly hack to have maximum precision in 32 bits
-       while (((realOsciFreq & 0x80000000) == 0) && (multiplier != 1))
-       {
-          realOsciFreq <<= 1;
-          multiplier >>= 1;
-       }
-       realOsciFreq /= totalTime;
-       if (multiplier) realOsciFreq *= multiplier;
+      multiplier = 4096;
+      realOsciFreq = (prescale + 1) * totalCounter; // first part calcutlation
+      // now follows an ugly hack to have maximum precision in 32 bits
+      while (((realOsciFreq & 0x80000000) == 0) && (multiplier != 1)) {
+        realOsciFreq <<= 1;
+        multiplier >>= 1;
+      }
+      realOsciFreq /= totalTime;
+      if (multiplier)
+        realOsciFreq *= multiplier;
 
-       countDeviations++;
-       Serial.printf("%4u", countDeviations);
-       Serial.printf(" Timestamp: %4" PRIu32 " ", totalTime);
-       Serial.printf(" Freq: %4u ", frozenCounter);
-       Serial.printf(" Counter: %6" PRIu32 " ", totalCounter);
-       Serial.printf(" calc.osci.freq: %9" PRIu32 "\n",realOsciFreq);
+      countDeviations++;
+      Serial.printf("%4u", countDeviations);
+      Serial.printf(" Timestamp: %4" PRIu32 " ", totalTime);
+      Serial.printf(" Freq: %4u ", frozenCounter);
+      Serial.printf(" Counter: %6" PRIu32 " ", totalCounter);
+      Serial.printf(" calc.osci.freq: %9" PRIu32 "\n", realOsciFreq);
     }
   }
-
 }
 #else
 
 void setup() {
   Serial.begin(115200);
   Serial.println("PCA9685 Oscillator test");
-  Serial.println("yet not available for your board."); // please help adapt the code!
+  Serial.println(
+      "yet not available for your board."); // please help adapt the code!
 }
 
 void loop() {}

--- a/examples/pwmtest/pwmtest.ino
+++ b/examples/pwmtest/pwmtest.ino
@@ -1,30 +1,30 @@
-/*************************************************** 
+/***************************************************
   This is an example for our Adafruit 16-channel PWM & Servo driver
   PWM test - this will drive 16 PWMs in a 'wave'
 
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/815
 
-  These drivers use I2C to communicate, 2 pins are required to  
+  These drivers use I2C to communicate, 2 pins are required to
   interface.
 
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Wire.h>
 #include <Adafruit_PWMServoDriver.h>
+#include <Wire.h>
 
 // called this way, it uses the default address 0x40
 Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 // you can also call it with a different address you want
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
+// Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
 // you can also call it with a different address and I2C interface
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
+// Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
 
 void setup() {
   Serial.begin(9600);
@@ -44,26 +44,27 @@ void setup() {
    * 2) Adjust setOscillatorFrequency() until the PWM update frequency is the
    *    expected value (50Hz for most ESCs)
    * Setting the value here is specific to each individual I2C PCA9685 chip and
-   * affects the calculations for the PWM update frequency. 
-   * Failure to correctly set the int.osc value will cause unexpected PWM results
+   * affects the calculations for the PWM update frequency.
+   * Failure to correctly set the int.osc value will cause unexpected PWM
+   * results
    */
   pwm.setOscillatorFrequency(27000000);
-  pwm.setPWMFreq(1600);  // This is the maximum PWM frequency
+  pwm.setPWMFreq(1600); // This is the maximum PWM frequency
 
-  // if you want to really speed stuff up, you can go into 'fast 400khz I2C' mode
-  // some i2c devices dont like this so much so if you're sharing the bus, watch
-  // out for this!
+  // if you want to really speed stuff up, you can go into 'fast 400khz I2C'
+  // mode some i2c devices dont like this so much so if you're sharing the bus,
+  // watch out for this!
   Wire.setClock(400000);
 }
 
 void loop() {
   // Drive each PWM in a 'wave'
-  for (uint16_t i=0; i<4096; i += 8) {
-    for (uint8_t pwmnum=0; pwmnum < 16; pwmnum++) {
-      pwm.setPWM(pwmnum, 0, (i + (4096/16)*pwmnum) % 4096 );
+  for (uint16_t i = 0; i < 4096; i += 8) {
+    for (uint8_t pwmnum = 0; pwmnum < 16; pwmnum++) {
+      pwm.setPWM(pwmnum, 0, (i + (4096 / 16) * pwmnum) % 4096);
     }
 #ifdef ESP8266
-    yield();  // take a breather, required for ESP8266
+    yield(); // take a breather, required for ESP8266
 #endif
   }
 }

--- a/examples/servo/servo.ino
+++ b/examples/servo/servo.ino
@@ -1,40 +1,44 @@
-/*************************************************** 
+/***************************************************
   This is an example for our Adafruit 16-channel PWM & Servo driver
   Servo test - this will drive 8 servos, one after the other on the
   first 8 pins of the PCA9685
 
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/815
-  
-  These drivers use I2C to communicate, 2 pins are required to  
+
+  These drivers use I2C to communicate, 2 pins are required to
   interface.
 
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Wire.h>
 #include <Adafruit_PWMServoDriver.h>
+#include <Wire.h>
 
 // called this way, it uses the default address 0x40
 Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 // you can also call it with a different address you want
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
+// Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x41);
 // you can also call it with a different address and I2C interface
-//Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
+// Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(0x40, Wire);
 
-// Depending on your servo make, the pulse width min and max may vary, you 
+// Depending on your servo make, the pulse width min and max may vary, you
 // want these to be as small/large as possible without hitting the hard stop
 // for max range. You'll have to tweak them as necessary to match the servos you
 // have!
-#define SERVOMIN  150 // This is the 'minimum' pulse length count (out of 4096)
-#define SERVOMAX  600 // This is the 'maximum' pulse length count (out of 4096)
-#define USMIN  600 // This is the rounded 'minimum' microsecond length based on the minimum pulse of 150
-#define USMAX  2400 // This is the rounded 'maximum' microsecond length based on the maximum pulse of 600
+#define SERVOMIN 150 // This is the 'minimum' pulse length count (out of 4096)
+#define SERVOMAX 600 // This is the 'maximum' pulse length count (out of 4096)
+#define USMIN \
+  600 // This is the rounded 'minimum' microsecond length based on the minimum
+      // pulse of 150
+#define USMAX \
+  2400 // This is the rounded 'maximum' microsecond length based on the maximum
+       // pulse of 600
 #define SERVO_FREQ 50 // Analog servos run at ~50 Hz updates
 
 // our servo # counter
@@ -58,26 +62,30 @@ void setup() {
    * 2) Adjust setOscillatorFrequency() until the PWM update frequency is the
    *    expected value (50Hz for most ESCs)
    * Setting the value here is specific to each individual I2C PCA9685 chip and
-   * affects the calculations for the PWM update frequency. 
-   * Failure to correctly set the int.osc value will cause unexpected PWM results
+   * affects the calculations for the PWM update frequency.
+   * Failure to correctly set the int.osc value will cause unexpected PWM
+   * results
    */
   pwm.setOscillatorFrequency(27000000);
-  pwm.setPWMFreq(SERVO_FREQ);  // Analog servos run at ~50 Hz updates
+  pwm.setPWMFreq(SERVO_FREQ); // Analog servos run at ~50 Hz updates
 
   delay(10);
 }
 
 // You can use this function if you'd like to set the pulse length in seconds
-// e.g. setServoPulse(0, 0.001) is a ~1 millisecond pulse width. It's not precise!
+// e.g. setServoPulse(0, 0.001) is a ~1 millisecond pulse width. It's not
+// precise!
 void setServoPulse(uint8_t n, double pulse) {
   double pulselength;
-  
-  pulselength = 1000000;   // 1,000,000 us per second
-  pulselength /= SERVO_FREQ;   // Analog servos run at ~60 Hz updates
-  Serial.print(pulselength); Serial.println(" us per period"); 
-  pulselength /= 4096;  // 12 bits of resolution
-  Serial.print(pulselength); Serial.println(" us per bit"); 
-  pulse *= 1000000;  // convert input seconds to us
+
+  pulselength = 1000000;     // 1,000,000 us per second
+  pulselength /= SERVO_FREQ; // Analog servos run at ~60 Hz updates
+  Serial.print(pulselength);
+  Serial.println(" us per period");
+  pulselength /= 4096; // 12 bits of resolution
+  Serial.print(pulselength);
+  Serial.println(" us per bit");
+  pulse *= 1000000; // convert input seconds to us
   pulse /= pulselength;
   Serial.println(pulse);
   pwm.setPWM(n, 0, pulse);
@@ -97,8 +105,9 @@ void loop() {
 
   delay(500);
 
-  // Drive each servo one at a time using writeMicroseconds(), it's not precise due to calculation rounding!
-  // The writeMicroseconds() function is used to mimic the Arduino Servo library writeMicroseconds() behavior. 
+  // Drive each servo one at a time using writeMicroseconds(), it's not precise
+  // due to calculation rounding! The writeMicroseconds() function is used to
+  // mimic the Arduino Servo library writeMicroseconds() behavior.
   for (uint16_t microsec = USMIN; microsec < USMAX; microsec++) {
     pwm.writeMicroseconds(servonum, microsec);
   }
@@ -111,5 +120,6 @@ void loop() {
   delay(500);
 
   servonum++;
-  if (servonum > 7) servonum = 0; // Testing the first 8 servo channels
+  if (servonum > 7)
+    servonum = 0; // Testing the first 8 servo channels
 }


### PR DESCRIPTION
This PR adds a dedicated clang-format CI job that runs first, before the build job.

## Changes:
- Add `.clang-format` configuration file
- Add `clang-format` job to CI workflow using clang-format-18 on ubuntu-24.04
- Build job now depends on clang-format passing (`needs: clang-format`)
- Apply clang-format to all source files (.cpp, .h, .ino)

## Testing:
- ✅ Verified with clang-format-18 (CI version)
- ✅ Verified with clang-format (default version)

cc @ladyada